### PR TITLE
Move app-specific prop types to own file

### DIFF
--- a/web/static/js/components/category_column.jsx
+++ b/web/static/js/components/category_column.jsx
@@ -1,4 +1,5 @@
 import React from "react"
+import * as AppPropTypes from '../prop-types'
 import styles from "./css_modules/category_column.css"
 
 function CategoryColumn(props) {
@@ -30,13 +31,8 @@ function CategoryColumn(props) {
 }
 
 CategoryColumn.propTypes = {
-  ideas: React.PropTypes.arrayOf(
-    React.PropTypes.shape({
-      category: React.PropTypes.string,
-      body: React.PropTypes.string,
-    }),
-  ).isRequired,
-  category: React.PropTypes.string.isRequired,
+  ideas: AppPropTypes.ideas.isRequired,
+  category: AppPropTypes.category.isRequired 
 }
 
 export default CategoryColumn

--- a/web/static/js/components/door_chime.jsx
+++ b/web/static/js/components/door_chime.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from "react"
-
+import * as AppPropTypes from '../prop-types'
 import chimeSound from "./chime_sound"
 
 class DoorChime extends Component {
@@ -27,12 +27,7 @@ class DoorChime extends Component {
 }
 
 DoorChime.propTypes = {
-  users: React.PropTypes.arrayOf(
-    React.PropTypes.shape({
-      name: React.PropTypes.string,
-      online_at: React.PropTypes.number,
-    }),
-  ).isRequired,
+  users: AppPropTypes.users.isRequired,
 }
 
 export default DoorChime

--- a/web/static/js/components/room.jsx
+++ b/web/static/js/components/room.jsx
@@ -5,6 +5,7 @@ import CategoryColumn from "./category_column"
 import IdeaSubmissionForm from "./idea_submission_form"
 import ActionItemToggle from "./action_item_toggle"
 import DoorChime from "./door_chime"
+import * as AppPropTypes from '../prop-types'
 
 import styles from "./css_modules/room.css"
 
@@ -60,16 +61,8 @@ class Room extends Component {
 }
 
 Room.propTypes = {
-  retroChannel: React.PropTypes.shape({
-    on: React.PropTypes.func,
-    push: React.PropTypes.func,
-  }).isRequired,
-  users: React.PropTypes.arrayOf(
-    React.PropTypes.shape({
-      name: React.PropTypes.string,
-      online_at: React.PropTypes.number,
-    }),
-  ).isRequired,
+  retroChannel: AppPropTypes.retroChannel.isRequired,
+  users: AppPropTypes.users.isRequired,
 }
 
 export default Room

--- a/web/static/js/components/user_list.jsx
+++ b/web/static/js/components/user_list.jsx
@@ -1,6 +1,6 @@
 import React from "react"
-
 import UserListItem from "./user_list_item"
+import * as AppPropTypes from '../prop-types'
 
 function UserList(props) {
   const usersSortedByArrival = props.users.sort((userOne, userTwo) => {
@@ -21,7 +21,7 @@ function UserList(props) {
 }
 
 UserList.propTypes = {
-  users: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
+  users: AppPropTypes.users.isRequired
 }
 
 export default UserList

--- a/web/static/js/components/user_list_item.jsx
+++ b/web/static/js/components/user_list_item.jsx
@@ -1,5 +1,5 @@
 import React from "react"
-
+import * as AppPropTypes from '../prop-types'
 import styles from "./css_modules/user_list_item.css"
 
 function UserListItem(props) {
@@ -16,11 +16,7 @@ function UserListItem(props) {
 }
 
 UserListItem.propTypes = {
-  user: React.PropTypes.shape({
-    given_name: React.PropTypes.string,
-    online_at: React.PropTypes.number,
-    facilitator: React.PropTypes.boolean,
-  }).isRequired,
+  user: AppPropTypes.user.isRequired
 }
 
 export default UserListItem

--- a/web/static/js/prop-types.js
+++ b/web/static/js/prop-types.js
@@ -1,0 +1,28 @@
+//
+// Reusable, domain-specific prop types
+//
+import { PropTypes } from 'react';
+
+// could be an enum if this is a fixed set of strings?
+export const category = PropTypes.string
+
+export const user = PropTypes.shape({
+  given_name: PropTypes.string,
+  online_at: PropTypes.number,
+  facilitator: PropTypes.boolean,
+})
+
+export const users = PropTypes.arrayOf(PropTypes.object)
+
+export const retroChannel = PropTypes.shape({
+  on: PropTypes.func,
+  push: PropTypes.func,
+})
+
+const idea = PropTypes.shape({
+  category,
+  body: PropTypes.string,
+})
+
+export const ideas = PropTypes.arrayOf(idea)
+


### PR DESCRIPTION
Helps with:
- Ensuring the contract, via props, for domain-specific objects and data types
- DRY as the desert
- This thing called testing

This pattern helped a lot at a couple Stride clients 👌.