### PR TITLE
Feature/attribute idea to user 52

### DIFF
--- a/priv/repo/migrations/20170328234201_add_author_column_to_ideas.exs
+++ b/priv/repo/migrations/20170328234201_add_author_column_to_ideas.exs
@@ -1,0 +1,9 @@
+defmodule RemoteRetro.Repo.Migrations.AddAuthorColumnToIdeas do
+  use Ecto.Migration
+
+  def change do
+    alter table(:ideas) do
+      add :author, :string
+    end
+  end
+end

--- a/test/channels/retro_channel_test.exs
+++ b/test/channels/retro_channel_test.exs
@@ -17,9 +17,9 @@ defmodule RemoteRetro.RetroChannelTest do
   end
 
   defp persist_idea_for_retro(context) do
-    %{idea_category: category, idea_body: body, retro: retro} = context
+    %{idea_category: category, idea_body: body, retro: retro, author: author} = context
 
-    changeset = %Idea{category: category, body: body, retro_id: retro.id}
+    changeset = %Idea{category: category, body: body, retro_id: retro.id, author: author}
     Repo.insert!(changeset)
     context
   end
@@ -57,22 +57,22 @@ defmodule RemoteRetro.RetroChannelTest do
   describe "joining a retro that already has a persisted idea" do
     setup [:persist_idea_for_retro, :join_the_retro_channel]
 
-    @tag idea_category: "sad", idea_body: "WIP commits on master"
+    @tag idea_category: "sad", idea_body: "WIP commits on master", author: "Travis"
     test "results in the assignment of all of those ideas to the socket", %{socket: socket} do
       assert length(socket.assigns.ideas) == 1
 
       sole_existing_idea = List.first(socket.assigns.ideas)
 
-      assert %{ body: "WIP commits on master", category: "sad", retro_id: _, id: _ } = sole_existing_idea
+      assert %{ body: "WIP commits on master", category: "sad", author: "Travis", retro_id: _, id: _ } = sole_existing_idea
     end
   end
 
   describe "pushing a new idea to the socket" do
     setup [:join_the_retro_channel]
     test "results in the broadcast of the new idea to all connected clients", %{ socket: socket } do
-      push(socket, "new_idea", %{ category: "happy", body: "we're pacing well" })
+      push(socket, "new_idea", %{ category: "happy", body: "we're pacing well", author: "Travis" })
 
-      assert_broadcast("new_idea_received", %{ category: "happy", body: "we're pacing well", id: _ })
+      assert_broadcast("new_idea_received", %{ category: "happy", body: "we're pacing well", id: _, author: "Travis" })
     end
   end
 

--- a/test/components/idea_submission_form_test.js
+++ b/test/components/idea_submission_form_test.js
@@ -18,7 +18,7 @@ describe("IdeaSubmissionForm component", () => {
   describe("on submit", () => {
     it("invokes the function passed as the onIdeaSubmission prop", () => {
       const onSubmitIdeaSpy = sinon.spy(() => {})
-      wrapper = mount(<IdeaSubmissionForm currentUser={stubbedUser} onIdeaSubmission={onSubmitIdeaSpy} showActionItem={true} />)
+      wrapper = mount(<IdeaSubmissionForm currentPresence={stubbedUser} onIdeaSubmission={onSubmitIdeaSpy} showActionItem={true} />)
 
       wrapper.simulate("submit", fakeEvent)
 
@@ -28,7 +28,7 @@ describe("IdeaSubmissionForm component", () => {
 
   describe("when the state's `category` value changes", () => {
     it("shifts focus to the idea input", () => {
-      wrapper = mount(<IdeaSubmissionForm currentUser={stubbedUser} onIdeaSubmission={onSubmitIdeaStub} showActionItem={true} />)
+      wrapper = mount(<IdeaSubmissionForm currentPresence={stubbedUser} onIdeaSubmission={onSubmitIdeaStub} showActionItem={true} />)
 
       const ideaInput = wrapper.find("input[name='idea']")
 
@@ -43,7 +43,7 @@ describe("IdeaSubmissionForm component", () => {
 
   describe("at the outset the form submit is disabled", () => {
     it("is enabled once there is an idea of 3 characters or longer", () => {
-      wrapper = mount(<IdeaSubmissionForm currentUser={stubbedUser} onIdeaSubmission={onSubmitIdeaStub} showActionItem={true} />)
+      wrapper = mount(<IdeaSubmissionForm currentPresence={stubbedUser} onIdeaSubmission={onSubmitIdeaStub} showActionItem={true} />)
       const submitButton = wrapper.find("button[type='submit']")
       const ideaInput = wrapper.find("input[name='idea']")
 
@@ -58,7 +58,7 @@ describe("IdeaSubmissionForm component", () => {
       beforeEach(() => {
         wrapper = mount(
           <IdeaSubmissionForm
-            currentUser={stubbedUser}
+            currentPresence={stubbedUser}
             onIdeaSubmission={onSubmitIdeaStub}
             showActionItem={false}
           />
@@ -86,7 +86,7 @@ describe("IdeaSubmissionForm component", () => {
 
   describe("the showActionItem prop", () => {
     it("when true results in the category list only rendering an 'action-item' option", () => {
-      wrapper = mount(<IdeaSubmissionForm currentUser={stubbedUser} onIdeaSubmission={onSubmitIdeaStub} showActionItem={true} />)
+      wrapper = mount(<IdeaSubmissionForm currentPresence={stubbedUser} onIdeaSubmission={onSubmitIdeaStub} showActionItem={true} />)
 
       const categorySelect = wrapper.find('select')
       expect(
@@ -95,7 +95,7 @@ describe("IdeaSubmissionForm component", () => {
     })
 
     it("when false results in the category list rendering options for the basic retro categories", () => {
-      wrapper = mount(<IdeaSubmissionForm currentUser={stubbedUser} onIdeaSubmission={onSubmitIdeaStub} showActionItem={false} />)
+      wrapper = mount(<IdeaSubmissionForm currentPresence={stubbedUser} onIdeaSubmission={onSubmitIdeaStub} showActionItem={false} />)
 
       const categorySelect = wrapper.find('select')
 

--- a/test/components/idea_submission_form_test.js
+++ b/test/components/idea_submission_form_test.js
@@ -8,6 +8,7 @@ import IdeaSubmissionForm from "../../web/static/js/components/idea_submission_f
 describe("IdeaSubmissionForm component", () => {
   let wrapper
 
+  const stubbedUser = { user: { given_name: "Mugatu" } }
   const onSubmitIdeaStub = () => {}
   const fakeEvent = {
     stopPropagation: () => undefined,
@@ -17,7 +18,7 @@ describe("IdeaSubmissionForm component", () => {
   describe("on submit", () => {
     it("invokes the function passed as the onIdeaSubmission prop", () => {
       const onSubmitIdeaSpy = sinon.spy(() => {})
-      wrapper = mount(<IdeaSubmissionForm onIdeaSubmission={onSubmitIdeaSpy} showActionItem={true} />)
+      wrapper = mount(<IdeaSubmissionForm currentUser={stubbedUser} onIdeaSubmission={onSubmitIdeaSpy} showActionItem={true} />)
 
       wrapper.simulate("submit", fakeEvent)
 
@@ -27,7 +28,7 @@ describe("IdeaSubmissionForm component", () => {
 
   describe("when the state's `category` value changes", () => {
     it("shifts focus to the idea input", () => {
-      wrapper = mount(<IdeaSubmissionForm onIdeaSubmission={onSubmitIdeaStub} showActionItem={true} />)
+      wrapper = mount(<IdeaSubmissionForm currentUser={stubbedUser} onIdeaSubmission={onSubmitIdeaStub} showActionItem={true} />)
 
       const ideaInput = wrapper.find("input[name='idea']")
 
@@ -42,7 +43,7 @@ describe("IdeaSubmissionForm component", () => {
 
   describe("at the outset the form submit is disabled", () => {
     it("is enabled once there is an idea of 3 characters or longer", () => {
-      wrapper = mount(<IdeaSubmissionForm onIdeaSubmission={onSubmitIdeaStub} showActionItem={true} />)
+      wrapper = mount(<IdeaSubmissionForm currentUser={stubbedUser} onIdeaSubmission={onSubmitIdeaStub} showActionItem={true} />)
       const submitButton = wrapper.find("button[type='submit']")
       const ideaInput = wrapper.find("input[name='idea']")
 
@@ -57,6 +58,7 @@ describe("IdeaSubmissionForm component", () => {
       beforeEach(() => {
         wrapper = mount(
           <IdeaSubmissionForm
+            currentUser={stubbedUser}
             onIdeaSubmission={onSubmitIdeaStub}
             showActionItem={false}
           />
@@ -84,7 +86,7 @@ describe("IdeaSubmissionForm component", () => {
 
   describe("the showActionItem prop", () => {
     it("when true results in the category list only rendering an 'action-item' option", () => {
-      wrapper = mount(<IdeaSubmissionForm onIdeaSubmission={onSubmitIdeaStub} showActionItem={true} />)
+      wrapper = mount(<IdeaSubmissionForm currentUser={stubbedUser} onIdeaSubmission={onSubmitIdeaStub} showActionItem={true} />)
 
       const categorySelect = wrapper.find('select')
       expect(
@@ -93,7 +95,7 @@ describe("IdeaSubmissionForm component", () => {
     })
 
     it("when false results in the category list rendering options for the basic retro categories", () => {
-      wrapper = mount(<IdeaSubmissionForm onIdeaSubmission={onSubmitIdeaStub} showActionItem={false} />)
+      wrapper = mount(<IdeaSubmissionForm currentUser={stubbedUser} onIdeaSubmission={onSubmitIdeaStub} showActionItem={false} />)
 
       const categorySelect = wrapper.find('select')
 

--- a/test/components/room_test.js
+++ b/test/components/room_test.js
@@ -15,7 +15,7 @@ describe("Room component", () => {
   describe(".handleIdeaSubmission", () => {
     it("pushes the idea to the room channel", () => {
       const roomComponent = shallow(
-        <Room currentUser={stubbedUser} retroChannel={mockRetroChannel} users={[]} />,
+        <Room currentPresence={stubbedUser} retroChannel={mockRetroChannel} users={[]} />,
       )
 
       roomComponent
@@ -32,7 +32,7 @@ describe("Room component", () => {
     context("and showActionItems is false", () => {
       it("renders the <StageProgressionButton>", () => {
         const roomComponent = shallow(
-          <Room currentUser={stubbedUser} retroChannel={mockRetroChannel} isFacilitator users={[]} />)
+          <Room currentPresence={stubbedUser} retroChannel={mockRetroChannel} isFacilitator users={[]} />)
 
         expect(roomComponent.find(StageProgressionButton)).to.have.length(1)
       })
@@ -41,7 +41,7 @@ describe("Room component", () => {
     context("and showActionItems is true", () => {
       it("does not render the <StageProgressionButton>", () => {
         const roomComponent = shallow(
-          <Room currentUser={stubbedUser} retroChannel={mockRetroChannel} isFacilitator users={[]} />)
+          <Room currentPresence={stubbedUser} retroChannel={mockRetroChannel} isFacilitator users={[]} />)
         roomComponent.setState({ showActionItem: true })
 
         expect(roomComponent.find(StageProgressionButton)).to.have.length(0)
@@ -51,7 +51,7 @@ describe("Room component", () => {
 
   context("when the current user is not facilitator", () => {
     it("does not render <StageProgressionButton>", () => {
-      const roomComponent = shallow(<Room currentUser={stubbedUser} retroChannel={mockRetroChannel} users={[]} />)
+      const roomComponent = shallow(<Room currentPresence={stubbedUser} retroChannel={mockRetroChannel} users={[]} />)
 
       expect(roomComponent.find(StageProgressionButton)).to.have.length(0)
     })
@@ -61,7 +61,7 @@ describe("Room component", () => {
     const retroChannel = { push: spy() }
 
     before(() => {
-      const wrapper = shallow(<Room currentUser={stubbedUser} retroChannel={retroChannel} isFacilitator users={[]} />)
+      const wrapper = shallow(<Room currentPresence={stubbedUser} retroChannel={retroChannel} isFacilitator users={[]} />)
 
       wrapper.find(StageProgressionButton).props().onProceedToActionItems()
     })
@@ -75,7 +75,7 @@ describe("Room component", () => {
   describe("Action item column", () => {
     it("is not visible on render", () => {
       const roomComponent = shallow(
-        <Room currentUser={stubbedUser} retroChannel={mockRetroChannel} users={[]} />,
+        <Room currentPresence={stubbedUser} retroChannel={mockRetroChannel} users={[]} />,
       )
 
       expect(roomComponent.containsMatchingElement(
@@ -85,7 +85,7 @@ describe("Room component", () => {
 
     it("becomes visible when showActionItem is true", () => {
       const roomComponent = shallow(
-        <Room currentUser={stubbedUser} retroChannel={mockRetroChannel} users={[]} />,
+        <Room currentPresence={stubbedUser} retroChannel={mockRetroChannel} users={[]} />,
       )
       roomComponent.setState({ showActionItem: true })
 
@@ -102,7 +102,7 @@ describe("Room component", () => {
     beforeEach(() => {
       retroChannel = RetroChannel.configure({})
       roomComponent = mount(
-        <Room currentUser={stubbedUser} retroChannel={retroChannel} users={[]} />,
+        <Room currentPresence={stubbedUser} retroChannel={retroChannel} users={[]} />,
       )
     })
 

--- a/test/components/room_test.js
+++ b/test/components/room_test.js
@@ -10,10 +10,11 @@ import StageProgressionButton from "../../web/static/js/components/stage_progres
 
 describe("Room component", () => {
   const mockRetroChannel = { push: spy(), on: () => {} }
+  const stubbedUser = "Mugatu"
 
   describe(".handleIdeaSubmission", () => {
     it("pushes the idea to the room channel", () => {
-      const roomComponent = shallow(<Room retroChannel={mockRetroChannel} users={[]} />)
+      const roomComponent = shallow(<Room currentUser={stubbedUser} retroChannel={mockRetroChannel} users={[]} />)
 
       roomComponent
         .instance()
@@ -71,7 +72,7 @@ describe("Room component", () => {
 
   describe("Action item column", () => {
     it("is not visible on render", () => {
-      const roomComponent = shallow(<Room retroChannel={mockRetroChannel} users={[]} />)
+      const roomComponent = shallow(<Room currentUser={stubbedUser} retroChannel={mockRetroChannel} users={[]} />)
 
       expect(roomComponent.containsMatchingElement(
         <CategoryColumn category="action-item" ideas={[]} />,
@@ -79,7 +80,7 @@ describe("Room component", () => {
     })
 
     it("becomes visible when showActionItem is true", () => {
-      const roomComponent = shallow(<Room retroChannel={mockRetroChannel} users={[]} />)
+      const roomComponent = shallow(<Room currentUser={stubbedUser} retroChannel={mockRetroChannel} users={[]} />)
       roomComponent.setState({ showActionItem: true })
 
       expect(roomComponent.containsMatchingElement(
@@ -94,7 +95,7 @@ describe("Room component", () => {
 
     beforeEach(() => {
       retroChannel = RetroChannel.configure({})
-      roomComponent = mount(<Room retroChannel={retroChannel} users={[]} />)
+      roomComponent = mount(<Room currentUser={stubbedUser} retroChannel={retroChannel} users={[]} />)
     })
 
     it("on `existing_ideas` sets the associated payload's `ideas` value on state", () => {

--- a/test/components/room_test.js
+++ b/test/components/room_test.js
@@ -10,7 +10,7 @@ import StageProgressionButton from "../../web/static/js/components/stage_progres
 
 describe("Room component", () => {
   const mockRetroChannel = { push: spy(), on: () => {} }
-  const stubbedUser = "Mugatu"
+  const stubbedUser = { user: { given_name: "Mugatu" } }
 
   describe(".handleIdeaSubmission", () => {
     it("pushes the idea to the room channel", () => {
@@ -32,7 +32,7 @@ describe("Room component", () => {
     context("and showActionItems is false", () => {
       it("renders the <StageProgressionButton>", () => {
         const roomComponent = shallow(
-          <Room retroChannel={mockRetroChannel} isFacilitator users={[]} />)
+          <Room currentUser={stubbedUser} retroChannel={mockRetroChannel} isFacilitator users={[]} />)
 
         expect(roomComponent.find(StageProgressionButton)).to.have.length(1)
       })
@@ -41,7 +41,7 @@ describe("Room component", () => {
     context("and showActionItems is true", () => {
       it("does not render the <StageProgressionButton>", () => {
         const roomComponent = shallow(
-          <Room retroChannel={mockRetroChannel} isFacilitator users={[]} />)
+          <Room currentUser={stubbedUser} retroChannel={mockRetroChannel} isFacilitator users={[]} />)
         roomComponent.setState({ showActionItem: true })
 
         expect(roomComponent.find(StageProgressionButton)).to.have.length(0)
@@ -51,7 +51,7 @@ describe("Room component", () => {
 
   context("when the current user is not facilitator", () => {
     it("does not render <StageProgressionButton>", () => {
-      const roomComponent = shallow(<Room retroChannel={mockRetroChannel} users={[]} />)
+      const roomComponent = shallow(<Room currentUser={stubbedUser} retroChannel={mockRetroChannel} users={[]} />)
 
       expect(roomComponent.find(StageProgressionButton)).to.have.length(0)
     })
@@ -61,7 +61,7 @@ describe("Room component", () => {
     const retroChannel = { push: spy() }
 
     before(() => {
-      const wrapper = shallow(<Room retroChannel={retroChannel} isFacilitator users={[]} />)
+      const wrapper = shallow(<Room currentUser={stubbedUser} retroChannel={retroChannel} isFacilitator users={[]} />)
 
       wrapper.find(StageProgressionButton).props().onProceedToActionItems()
     })

--- a/test/components/room_test.js
+++ b/test/components/room_test.js
@@ -14,7 +14,9 @@ describe("Room component", () => {
 
   describe(".handleIdeaSubmission", () => {
     it("pushes the idea to the room channel", () => {
-      const roomComponent = shallow(<Room currentUser={stubbedUser} retroChannel={mockRetroChannel} users={[]} />)
+      const roomComponent = shallow(
+        <Room currentUser={stubbedUser} retroChannel={mockRetroChannel} users={[]} />,
+      )
 
       roomComponent
         .instance()
@@ -72,7 +74,9 @@ describe("Room component", () => {
 
   describe("Action item column", () => {
     it("is not visible on render", () => {
-      const roomComponent = shallow(<Room currentUser={stubbedUser} retroChannel={mockRetroChannel} users={[]} />)
+      const roomComponent = shallow(
+        <Room currentUser={stubbedUser} retroChannel={mockRetroChannel} users={[]} />,
+      )
 
       expect(roomComponent.containsMatchingElement(
         <CategoryColumn category="action-item" ideas={[]} />,
@@ -80,7 +84,9 @@ describe("Room component", () => {
     })
 
     it("becomes visible when showActionItem is true", () => {
-      const roomComponent = shallow(<Room currentUser={stubbedUser} retroChannel={mockRetroChannel} users={[]} />)
+      const roomComponent = shallow(
+        <Room currentUser={stubbedUser} retroChannel={mockRetroChannel} users={[]} />,
+      )
       roomComponent.setState({ showActionItem: true })
 
       expect(roomComponent.containsMatchingElement(
@@ -95,7 +101,9 @@ describe("Room component", () => {
 
     beforeEach(() => {
       retroChannel = RetroChannel.configure({})
-      roomComponent = mount(<Room currentUser={stubbedUser} retroChannel={retroChannel} users={[]} />)
+      roomComponent = mount(
+        <Room currentUser={stubbedUser} retroChannel={retroChannel} users={[]} />,
+      )
     })
 
     it("on `existing_ideas` sets the associated payload's `ideas` value on state", () => {

--- a/test/features/existing_ideas_rendered_on_joining_retro_test.exs
+++ b/test/features/existing_ideas_rendered_on_joining_retro_test.exs
@@ -10,6 +10,6 @@ defmodule ExistingIdeasRenderedOnJoiningRetroTest do
 
     ideas_list_text = session |> find(Query.css(".happy.ideas")) |> Element.text
 
-    assert String.contains?(ideas_list_text, "continuous delivery!")
+    assert String.contains?(ideas_list_text, "Travis: continuous delivery!")
   end
 end

--- a/test/features/existing_ideas_rendered_on_joining_retro_test.exs
+++ b/test/features/existing_ideas_rendered_on_joining_retro_test.exs
@@ -3,7 +3,7 @@ defmodule ExistingIdeasRenderedOnJoiningRetroTest do
   alias RemoteRetro.Idea
 
   test "the rendering of ideas submitted prior to the user joining", %{session: session, retro: retro} do
-    Repo.insert!(%Idea{ category: "happy", body: "continuous delivery!", retro_id: retro.id })
+    Repo.insert!(%Idea{ category: "happy", body: "continuous delivery!", retro_id: retro.id, author: "Travis" })
 
     retro_path = "/retros/" <> retro.id
     session = visit(session, retro_path)

--- a/web/channels/retro_channel.ex
+++ b/web/channels/retro_channel.ex
@@ -9,7 +9,7 @@ defmodule RemoteRetro.RetroChannel do
   alias RemoteRetro.Idea
 
   def join("retro:" <> retro_id, _, socket) do
-    query = from idea in Idea, select: map(idea, [:body, :category, :inserted_at, :retro_id, :id]), where: idea.retro_id == ^retro_id
+    query = from idea in Idea, where: idea.retro_id == ^retro_id
     existing_ideas = Repo.all(query)
     socket_ideas = Phoenix.Socket.assign(socket, :ideas, existing_ideas)
     socket_retro = Phoenix.Socket.assign(socket_ideas, :retro_id, retro_id)
@@ -28,8 +28,8 @@ defmodule RemoteRetro.RetroChannel do
     {:noreply, socket}
   end
 
-  def handle_in("new_idea", %{"body" => body, "category" => category}, socket) do
-    changeset = Idea.changeset(%Idea{body: body, category: category, retro_id: socket.assigns.retro_id})
+  def handle_in("new_idea", %{"body" => body, "category" => category, "author" => author}, socket) do
+    changeset = Idea.changeset(%Idea{body: body, category: category, retro_id: socket.assigns.retro_id, author: author})
     idea = Repo.insert!(changeset)
 
     broadcast! socket, "new_idea_received", idea

--- a/web/models/idea.ex
+++ b/web/models/idea.ex
@@ -6,13 +6,14 @@ defmodule RemoteRetro.Idea do
   schema "ideas" do
     field :category, :string
     field :body, :string
+    field :author, :string
 
     belongs_to :retro, RemoteRetro.Retro, type: Ecto.UUID
 
     timestamps()
   end
 
-  @required_fields [:category, :body, :retro_id]
+  @required_fields [:category, :body, :retro_id, :author]
 
   def changeset(struct, params \\ %{}) do
     struct

--- a/web/static/js/components/category_column.jsx
+++ b/web/static/js/components/category_column.jsx
@@ -12,9 +12,9 @@ function CategoryColumn(props) {
 
   const emoticonUnicode = categoryToEmoticonUnicodeMap[props.category]
   const filteredIdeas = props.ideas.filter(idea => idea.category === props.category)
-  const filteredIdeasList = filteredIdeas.map(idea =>
-    <li className="item" title={idea.body} key={idea.id}>{props.currentUser}: {idea.body}</li>,
-  )
+  const filteredIdeasList = filteredIdeas.map(idea => {
+    return <li className="item" title={idea.body} key={idea.id}>{idea.author}: {idea.body}</li>
+  })
 
   return (
     <section className={`${props.category} column`}>

--- a/web/static/js/components/category_column.jsx
+++ b/web/static/js/components/category_column.jsx
@@ -13,7 +13,7 @@ function CategoryColumn(props) {
   const emoticonUnicode = categoryToEmoticonUnicodeMap[props.category]
   const filteredIdeas = props.ideas.filter(idea => idea.category === props.category)
   const filteredIdeasList = filteredIdeas.map(idea =>
-    <li className="item" title={idea.body} key={idea.id}>{idea.body}</li>,
+    <li className="item" title={idea.body} key={idea.id}>{props.currentUser}: {idea.body}</li>,
   )
 
   return (

--- a/web/static/js/components/idea_submission_form.jsx
+++ b/web/static/js/components/idea_submission_form.jsx
@@ -24,10 +24,10 @@ class IdeaSubmissionForm extends Component {
   }
 
   handleSubmit(event) {
-    const { currentUser } = this.props
+    const { currentPresence } = this.props
     event.preventDefault()
     this.setState({ body: "" })
-    this.props.onIdeaSubmission({ ...this.state, author: currentUser.user.given_name })
+    this.props.onIdeaSubmission({ ...this.state, author: currentPresence.user.given_name })
   }
 
   handleIdeaChange(event) {

--- a/web/static/js/components/idea_submission_form.jsx
+++ b/web/static/js/components/idea_submission_form.jsx
@@ -24,9 +24,10 @@ class IdeaSubmissionForm extends Component {
   }
 
   handleSubmit(event) {
+    const { currentUser } = this.props
     event.preventDefault()
     this.setState({ body: "" })
-    this.props.onIdeaSubmission(this.state)
+    this.props.onIdeaSubmission({ ...this.state, author: currentUser.user.given_name })
   }
 
   handleIdeaChange(event) {

--- a/web/static/js/components/remote_retro.jsx
+++ b/web/static/js/components/remote_retro.jsx
@@ -43,6 +43,8 @@ class RemoteRetro extends Component {
 }
 
 RemoteRetro.propTypes = {
+  userToken: React.PropTypes.string.isRequired,
+  retroUUID: React.PropTypes.string.isRequired,
   retroChannel: AppPropTypes.retroChannel.isRequired,
   userToken: PropTypes.string.isRequired,
 }

--- a/web/static/js/components/remote_retro.jsx
+++ b/web/static/js/components/remote_retro.jsx
@@ -34,6 +34,7 @@ class RemoteRetro extends Component {
 
     return (
       <Room
+        currentUser={currentPresence}
         users={users}
         isFacilitator={isFacilitator(currentPresence)}
         retroChannel={retroChannel}
@@ -44,7 +45,6 @@ class RemoteRetro extends Component {
 
 RemoteRetro.propTypes = {
   userToken: React.PropTypes.string.isRequired,
-  retroUUID: React.PropTypes.string.isRequired,
   retroChannel: AppPropTypes.retroChannel.isRequired,
   userToken: PropTypes.string.isRequired,
 }

--- a/web/static/js/components/remote_retro.jsx
+++ b/web/static/js/components/remote_retro.jsx
@@ -34,7 +34,7 @@ class RemoteRetro extends Component {
 
     return (
       <Room
-        currentUser={currentPresence}
+        currentPresence={currentPresence}
         users={users}
         isFacilitator={isFacilitator(currentPresence)}
         retroChannel={retroChannel}

--- a/web/static/js/components/room.jsx
+++ b/web/static/js/components/room.jsx
@@ -1,4 +1,4 @@
-import React, { Component, PropTypes } from "react"
+import React, { Component } from "react"
 
 import UserList from "./user_list"
 import CategoryColumn from "./category_column"
@@ -46,16 +46,16 @@ class Room extends Component {
     return (
       <section className={styles.wrapper}>
         <div className={`ui equal width padded grid ${styles.categoryColumnsWrapper}`}>
-          <CategoryColumn category="happy" currentUser={currentUser} ideas={ideas} />
-          <CategoryColumn category="sad" currentUser={currentUser} ideas={ideas} />
-          <CategoryColumn category="confused" currentUser={currentUser} ideas={ideas} />
-          { showActionItem ? <CategoryColumn category="action-item" ideas={ideas} /> : null }
+          <CategoryColumn category="happy" ideas={ideas} />
+          <CategoryColumn category="sad" ideas={ideas} />
+          <CategoryColumn category="confused" ideas={ideas} />
+          { showActionItem ? <CategoryColumn category="action-item" /> : null }
         </div>
 
         <UserList users={users} />
         <div className="ui stackable grid basic attached secondary segment">
           <div className="thirteen wide column">
-            <IdeaSubmissionForm onIdeaSubmission={this.handleIdeaSubmission} showActionItem={showActionItem} />
+            <IdeaSubmissionForm currentUser={currentUser} onIdeaSubmission={this.handleIdeaSubmission} showActionItem={showActionItem} />
           </div>
           <div className="three wide right aligned column">
             { this.props.isFacilitator && retroHasYetToProgressToActionItems &&
@@ -74,7 +74,6 @@ Room.defaultProps = {
 }
 
 Room.propTypes = {
-  currentUser: PropTypes.string.isRequired,
   retroChannel: AppPropTypes.retroChannel.isRequired,
   users: AppPropTypes.users.isRequired,
   isFacilitator: React.PropTypes.bool,

--- a/web/static/js/components/room.jsx
+++ b/web/static/js/components/room.jsx
@@ -49,7 +49,7 @@ class Room extends Component {
           <CategoryColumn category="happy" ideas={ideas} />
           <CategoryColumn category="sad" ideas={ideas} />
           <CategoryColumn category="confused" ideas={ideas} />
-          { showActionItem ? <CategoryColumn category="action-item" /> : null }
+          { showActionItem ? <CategoryColumn category="action-item" ideas={ideas} /> : null }
         </div>
 
         <UserList users={users} />

--- a/web/static/js/components/room.jsx
+++ b/web/static/js/components/room.jsx
@@ -41,7 +41,7 @@ class Room extends Component {
 
   render() {
     const retroHasYetToProgressToActionItems = !this.state.showActionItem
-    const { currentUser, users } = this.props
+    const { currentPresence, users } = this.props
     const { ideas, showActionItem } = this.state
     return (
       <section className={styles.wrapper}>
@@ -55,7 +55,7 @@ class Room extends Component {
         <UserList users={users} />
         <div className="ui stackable grid basic attached secondary segment">
           <div className="thirteen wide column">
-            <IdeaSubmissionForm currentUser={currentUser} onIdeaSubmission={this.handleIdeaSubmission} showActionItem={showActionItem} />
+            <IdeaSubmissionForm currentPresence={currentPresence} onIdeaSubmission={this.handleIdeaSubmission} showActionItem={showActionItem} />
           </div>
           <div className="three wide right aligned column">
             { this.props.isFacilitator && retroHasYetToProgressToActionItems &&

--- a/web/static/js/components/room.jsx
+++ b/web/static/js/components/room.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from "react"
+import React, { Component, PropTypes } from "react"
 
 import UserList from "./user_list"
 import CategoryColumn from "./category_column"
@@ -41,25 +41,21 @@ class Room extends Component {
 
   render() {
     const retroHasYetToProgressToActionItems = !this.state.showActionItem
-
+    const { currentUser, users } = this.props
+    const { ideas, showActionItem } = this.state
     return (
       <section className={styles.wrapper}>
         <div className={`ui equal width padded grid ${styles.categoryColumnsWrapper}`}>
-          <CategoryColumn category="happy" ideas={this.state.ideas} />
-          <CategoryColumn category="sad" ideas={this.state.ideas} />
-          <CategoryColumn category="confused" ideas={this.state.ideas} />
-          { this.state.showActionItem
-            ? <CategoryColumn category="action-item" ideas={this.state.ideas} /> : null
-          }
+          <CategoryColumn category="happy" currentUser={currentUser} ideas={ideas} />
+          <CategoryColumn category="sad" currentUser={currentUser} ideas={ideas} />
+          <CategoryColumn category="confused" currentUser={currentUser} ideas={ideas} />
+          { showActionItem ? <CategoryColumn category="action-item" ideas={ideas} /> : null }
         </div>
 
-        <UserList users={this.props.users} />
+        <UserList users={users} />
         <div className="ui stackable grid basic attached secondary segment">
           <div className="thirteen wide column">
-            <IdeaSubmissionForm
-              onIdeaSubmission={this.handleIdeaSubmission}
-              showActionItem={this.state.showActionItem}
-            />
+            <IdeaSubmissionForm onIdeaSubmission={this.handleIdeaSubmission} showActionItem={showActionItem} />
           </div>
           <div className="three wide right aligned column">
             { this.props.isFacilitator && retroHasYetToProgressToActionItems &&
@@ -67,7 +63,7 @@ class Room extends Component {
             }
           </div>
         </div>
-        <DoorChime users={this.props.users} />
+        <DoorChime users={users} />
       </section>
     )
   }
@@ -78,6 +74,7 @@ Room.defaultProps = {
 }
 
 Room.propTypes = {
+  currentUser: PropTypes.string.isRequired,
   retroChannel: AppPropTypes.retroChannel.isRequired,
   users: AppPropTypes.users.isRequired,
   isFacilitator: React.PropTypes.bool,


### PR DESCRIPTION
@vanderhoop Season's greetings!

Here's a PR for #52, which focuses on tethering an author to an idea. @peterylai was also a core contributor to this feature.

One design concession we made was passing the entire `currentUser` object down the component chain as a prop; we would have preferred to evaluate `currentUser.user.given_name` much further upstream, but due to the rendering issues we've discussed (e.g. multiple `render` invocations on the same component, with prop values as `undefined` on first render), this would have required conditional logic that felt a bit dirty. This will hopefully be be solved upon our move to Redux.