### PR TITLE
Convert stateless components to ES6 consts

### DIFF
--- a/web/static/js/components/category_column.jsx
+++ b/web/static/js/components/category_column.jsx
@@ -3,7 +3,7 @@ import Idea from "./idea"
 import * as AppPropTypes from "../prop_types"
 import styles from "./css_modules/category_column.css"
 
-function CategoryColumn(props) {
+const CategoryColumn = props => {
   const categoryToEmoticonUnicodeMap = {
     happy: "😊",
     sad: "😥",

--- a/web/static/js/components/idea.jsx
+++ b/web/static/js/components/idea.jsx
@@ -4,7 +4,7 @@ import IdeaEditForm from "./idea_edit_form"
 import * as AppPropTypes from "../prop_types"
 import styles from "./css_modules/idea.css"
 
-function Idea(props) {
+const Idea = props => {
   const { idea, currentUser, retroChannel } = props
   const isFacilitator = currentUser.is_facilitator
   const isEdited = new Date(idea.updated_at) > new Date(idea.inserted_at)

--- a/web/static/js/components/idea_controls.jsx
+++ b/web/static/js/components/idea_controls.jsx
@@ -2,7 +2,7 @@ import React from "react"
 import * as AppPropTypes from "../prop_types"
 import styles from "./css_modules/idea_controls.css"
 
-function IdeaControls(props) {
+const IdeaControls = props => {
   const { idea, retroChannel } = props
 
   return (

--- a/web/static/js/components/room.jsx
+++ b/web/static/js/components/room.jsx
@@ -11,7 +11,7 @@ import DoorChime from "./door_chime"
 import * as AppPropTypes from "../prop_types"
 import styles from "./css_modules/room.css"
 
-function Room(props) {
+const Room = props => {
   const { currentUser, users, retroChannel, ideas, stage } = props
   const isFacilitator = currentUser.is_facilitator
   const categories = ["happy", "sad", "confused"]
@@ -62,7 +62,7 @@ function Room(props) {
 }
 
 Room.defaultProps = {
-  currentUser: { is_facilitator: false }
+  currentUser: { is_facilitator: false },
 }
 
 Room.propTypes = {

--- a/web/static/js/components/user_list.jsx
+++ b/web/static/js/components/user_list.jsx
@@ -2,7 +2,7 @@ import React from "react"
 import UserListItem from "./user_list_item"
 import * as AppPropTypes from "../prop_types"
 
-function UserList(props) {
+const UserList = props => {
   const usersSortedByArrival = props.users.sort((userOne, userTwo) =>
     userOne.online_at > userTwo.online_at
   )

--- a/web/static/js/components/user_list_item.jsx
+++ b/web/static/js/components/user_list_item.jsx
@@ -2,7 +2,7 @@ import React from "react"
 import * as AppPropTypes from "../prop_types"
 import styles from "./css_modules/user_list_item.css"
 
-function UserListItem(props) {
+const UserListItem = props => {
   let userName = props.user.given_name
   if (props.user.is_facilitator) userName += " (Facilitator)"
   return (


### PR DESCRIPTION
Some stateless components were using the old `function` syntax. Here I've converted them into `const`s.