### PR TITLE
Kill RemoteRetro's local state in favor of redux store

### DIFF
--- a/test/actions/idea_actions_test.js
+++ b/test/actions/idea_actions_test.js
@@ -8,14 +8,6 @@ describe("addIdea", () => {
   })
 })
 
-describe("setIdeas", () => {
-  it("creates an action to set ideas on the store", () => {
-    const ideas = [{ body: "Brett Favre", category: "happy", author: "Kimberly Suazo" }]
-
-    expect(actionCreators.setIdeas(ideas)).to.deep.equal({ type: "SET_IDEAS", ideas })
-  })
-})
-
 describe("updateIdea", () => {
   it("creates an action to update an idea with particular id with new attributes", () => {
     const ideaId = 999

--- a/test/actions/retro_actions_test.js
+++ b/test/actions/retro_actions_test.js
@@ -11,3 +11,15 @@ describe("updateStage", () => {
   })
 })
 
+describe("setInitialState", () => {
+  it("creates an action to set the retro's initial state", () => {
+    const initialState = { stage: "idea-generation", inserted_at: "2017-04-14T17:30:10" }
+
+    expect(actionCreators.setInitialState(initialState)).to.deep.equal({
+      type: "SET_INITIAL_STATE",
+      initialState,
+    })
+  })
+})
+
+

--- a/test/components/remote_retro_test.js
+++ b/test/components/remote_retro_test.js
@@ -13,19 +13,32 @@ describe("<RemoteRetro>", () => {
     let addIdeaSpy
     let deleteIdeaSpy
     let updateIdeaSpy
+    let updateStageSpy
 
     beforeEach(() => {
       addIdeaSpy = spy()
       deleteIdeaSpy = spy()
       updateIdeaSpy = spy()
+      updateStageSpy = spy()
 
       actions = {
         addIdea: addIdeaSpy,
         deleteIdea: deleteIdeaSpy,
         updateIdea: updateIdeaSpy,
+        updateStage: updateStageSpy,
       }
+
       retroChannel = RetroChannel.configure({})
-      wrapper = shallow(<RemoteRetro users={[]} ideas={[]} actions={actions} userToken="userToken" retroChannel={retroChannel} />)
+      wrapper = shallow(
+        <RemoteRetro
+          users={[]}
+          ideas={[]}
+          stage="idea-generation"
+          actions={actions}
+          userToken="userToken"
+          retroChannel={retroChannel}
+        />
+      )
     })
 
     describe("on `new_idea_received`", () => {
@@ -36,11 +49,9 @@ describe("<RemoteRetro>", () => {
     })
 
     describe("on `proceed_to_next_stage`", () => {
-      it("updates the state's `stage` attribute to the value from proceed_to_next_stage", () => {
-        expect(wrapper.state("stage")).to.equal("idea-generation")
+      it("invokes the updateStage action, passing the stage from the payload", () => {
         retroChannel.trigger("proceed_to_next_stage", { stage: "dummy value" })
-
-        expect(wrapper.state("stage")).to.equal("dummy value")
+        expect(updateStageSpy.calledWith("dummy value")).to.equal(true)
       })
 
       context("when the `stage` in the payload is 'action-item-distribution'", () => {
@@ -99,6 +110,7 @@ describe("<RemoteRetro>", () => {
             <RemoteRetro
               users={initialUsers}
               userToken="userToken"
+              stage="idea-generation"
               retroChannel={retroChannel}
               actions={actions}
               ideas={[]}

--- a/test/reducers/idea_reducer_test.js
+++ b/test/reducers/idea_reducer_test.js
@@ -48,6 +48,18 @@ describe("idea reducer", () => {
       })
     })
 
+    describe("when the action is SET_INITIAL_STATE", () => {
+      it("should replace the state with the ideas passed in the action's inialState object", () => {
+        const initialIdeas = [{ body: "i'm an old idea!", category: "happy", author: "Morty" }]
+        deepFreeze(initialIdeas)
+
+        const newIdeas = [{ body: "modern convenience", category: "confused", author: "Kimberly Suazo" }]
+        const action = { type: "SET_INITIAL_STATE", initialState: { ideas: newIdeas } }
+
+        expect(ideaReducer(initialIdeas, action)).to.deep.equal([...newIdeas])
+      })
+    })
+
     describe("when the action is UPDATE_IDEA", () => {
       const initialIdeas = [{ id: 666, category: "happy", author: "Kimberly" }, { id: 22, category: "n/a", author: "Travis" }]
       deepFreeze(initialIdeas)

--- a/test/reducers/idea_reducer_test.js
+++ b/test/reducers/idea_reducer_test.js
@@ -36,18 +36,6 @@ describe("idea reducer", () => {
       })
     })
 
-    describe("when the action is SET_IDEAS", () => {
-      it("should replace the state with the ideas passed in the action", () => {
-        const initialIdeas = [{ body: "i'm an old idea!", category: "happy", author: "Morty" }]
-        deepFreeze(initialIdeas)
-
-        const ideas = [{ body: "modern convenience", category: "confused", author: "Kimberly Suazo" }]
-        const action = { type: "SET_IDEAS", ideas }
-
-        expect(ideaReducer(initialIdeas, action)).to.deep.equal([...ideas])
-      })
-    })
-
     describe("when the action is SET_INITIAL_STATE", () => {
       it("should replace the state with the ideas passed in the action's inialState object", () => {
         const initialIdeas = [{ body: "i'm an old idea!", category: "happy", author: "Morty" }]

--- a/test/reducers/inserted_at_test.js
+++ b/test/reducers/inserted_at_test.js
@@ -1,0 +1,28 @@
+import insertedAtReducer from "../../web/static/js/reducers/inserted_at"
+
+describe("insertedAt reducer", () => {
+  describe("unhandled actions", () => {
+    describe("when there is an empty action", () => {
+      describe("when no initial state is passed", () => {
+        it("should return an initial state of null", () => {
+          expect(insertedAtReducer(undefined, { type: "unknown" })).to.equal(null)
+        })
+      })
+
+      describe("when an initial state is passed", () => {
+        it("should return the initial state of 'idea-generation'", () => {
+          expect(insertedAtReducer("2017-04-14T17:30:10", {})).to.equal("2017-04-14T17:30:10")
+        })
+      })
+    })
+  })
+
+  describe("handled actions", () => {
+    describe("when invoked with a SET_INITIAL_STATE action", () => {
+      it("returns the persisted state's 'inserted_at' value", () => {
+        const action = { type: "SET_INITIAL_STATE", initialState: { inserted_at: "holy mother of jeebus" } }
+        expect(insertedAtReducer(undefined, action)).to.equal("holy mother of jeebus")
+      })
+    })
+  })
+})

--- a/test/reducers/stage_reducer_test.js
+++ b/test/reducers/stage_reducer_test.js
@@ -4,8 +4,8 @@ describe("stage reducer", () => {
   describe("unhandled actions", () => {
     describe("when there is an empty action", () => {
       describe("when no initial state is passed", () => {
-        it("should return the initial state of 'idea-generation'", () => {
-          expect(stageReducer(undefined, {})).to.equal("idea-generation")
+        it("should return an empty string", () => {
+          expect(stageReducer(undefined, {})).to.equal("")
         })
       })
 

--- a/test/reducers/stage_reducer_test.js
+++ b/test/reducers/stage_reducer_test.js
@@ -27,4 +27,13 @@ describe("stage reducer", () => {
       })
     })
   })
+
+  describe("handled actions", () => {
+    describe("when invoked with a SET_INITIAL_STATE action", () => {
+      it("returns the value passed as the initial state's 'stage' attribute", () => {
+        const action = { type: "SET_INITIAL_STATE", initialState: { stage: "critical" } }
+        expect(stageReducer("Atari Bigby", action)).to.equal("critical")
+      })
+    })
+  })
 })

--- a/web/static/js/actions/idea.js
+++ b/web/static/js/actions/idea.js
@@ -3,11 +3,6 @@ export const addIdea = idea => ({
   idea,
 })
 
-export const setIdeas = ideas => ({
-  type: "SET_IDEAS",
-  ideas,
-})
-
 export const updateIdea = (ideaId, newAttributes) => ({
   type: "UPDATE_IDEA",
   ideaId,

--- a/web/static/js/actions/retro.js
+++ b/web/static/js/actions/retro.js
@@ -2,3 +2,8 @@ export const updateStage = newStage => ({
   type: "UPDATE_STAGE",
   stage: newStage,
 })
+
+export const setInitialState = initialState => ({
+  type: "SET_INITIAL_STATE",
+  initialState,
+})

--- a/web/static/js/components/remote_retro.jsx
+++ b/web/static/js/components/remote_retro.jsx
@@ -22,7 +22,6 @@ export class RemoteRetro extends Component {
       .receive("ok", retroState => {
         actions.setInitialState(retroState)
         actions.updateStage(retroState.stage)
-        actions.setIdeas(retroState.ideas)
       })
       .receive("error", error => console.error(error))
 

--- a/web/static/js/components/remote_retro.jsx
+++ b/web/static/js/components/remote_retro.jsx
@@ -5,6 +5,7 @@ import { Presence } from "phoenix"
 
 import * as userActionCreators from "../actions/user"
 import * as ideaActionCreators from "../actions/idea"
+import * as retroActionCreators from "../actions/retro"
 import * as AppPropTypes from "../prop_types"
 import Room from "./room"
 import ShareRetroLinkModal from "./share_retro_link_modal"
@@ -12,9 +13,7 @@ import ShareRetroLinkModal from "./share_retro_link_modal"
 export class RemoteRetro extends Component {
   constructor(props) {
     super(props)
-    this.state = {
-      stage: "idea-generation",
-    }
+    this.state = {}
   }
 
   componentWillMount() {
@@ -23,6 +22,7 @@ export class RemoteRetro extends Component {
     retroChannel.join()
       .receive("ok", retroState => {
         this.setState(retroState)
+        actions.updateStage(retroState.stage)
         actions.setIdeas(retroState.ideas)
       })
       .receive("error", error => console.error(error))
@@ -37,7 +37,7 @@ export class RemoteRetro extends Component {
     })
 
     retroChannel.on("proceed_to_next_stage", payload => {
-      this.setState({ stage: payload.stage })
+      actions.updateStage(payload.stage)
       if (payload.stage === "action-item-distribution") {
         alert(
           "The facilitator has distibuted this retro's action items. You will receive an email breakdown shortly."
@@ -82,8 +82,8 @@ export class RemoteRetro extends Component {
   }
 
   render() {
-    const { users, ideas, userToken, retroChannel } = this.props
-    const { stage, inserted_at } = this.state
+    const { users, ideas, userToken, retroChannel, stage } = this.props
+    const { inserted_at } = this.state
 
     const currentUser = users.find(user => user.token === userToken)
 
@@ -118,12 +118,14 @@ RemoteRetro.defaultProps = {
 const mapStateToProps = state => ({
   users: state.user,
   ideas: state.idea,
+  stage: state.stage,
 })
 
 const mapDispatchToProps = dispatch => ({
   actions: bindActionCreators({
     ...userActionCreators,
     ...ideaActionCreators,
+    ...retroActionCreators,
   }, dispatch),
 })
 

--- a/web/static/js/components/remote_retro.jsx
+++ b/web/static/js/components/remote_retro.jsx
@@ -19,10 +19,7 @@ export class RemoteRetro extends Component {
     const { retroChannel, actions } = this.props
 
     retroChannel.join()
-      .receive("ok", retroState => {
-        actions.setInitialState(retroState)
-        actions.updateStage(retroState.stage)
-      })
+      .receive("ok", actions.setInitialState)
       .receive("error", error => console.error(error))
 
     retroChannel.on("presence_state", presences => {

--- a/web/static/js/components/remote_retro.jsx
+++ b/web/static/js/components/remote_retro.jsx
@@ -13,7 +13,6 @@ import ShareRetroLinkModal from "./share_retro_link_modal"
 export class RemoteRetro extends Component {
   constructor(props) {
     super(props)
-    this.state = {}
   }
 
   componentWillMount() {
@@ -21,7 +20,7 @@ export class RemoteRetro extends Component {
 
     retroChannel.join()
       .receive("ok", retroState => {
-        this.setState(retroState)
+        actions.setInitialState(retroState)
         actions.updateStage(retroState.stage)
         actions.setIdeas(retroState.ideas)
       })
@@ -82,8 +81,7 @@ export class RemoteRetro extends Component {
   }
 
   render() {
-    const { users, ideas, userToken, retroChannel, stage } = this.props
-    const { inserted_at } = this.state
+    const { users, ideas, userToken, retroChannel, stage, insertedAt } = this.props
 
     const currentUser = users.find(user => user.token === userToken)
 
@@ -96,7 +94,7 @@ export class RemoteRetro extends Component {
           stage={stage}
           retroChannel={retroChannel}
         />
-        <ShareRetroLinkModal retroCreationTimestamp={inserted_at} />
+        <ShareRetroLinkModal retroCreationTimestamp={insertedAt} />
       </div>
     )
   }
@@ -119,6 +117,7 @@ const mapStateToProps = state => ({
   users: state.user,
   ideas: state.idea,
   stage: state.stage,
+  insertedAt: state.insertedAt,
 })
 
 const mapDispatchToProps = dispatch => ({

--- a/web/static/js/components/remote_retro.jsx
+++ b/web/static/js/components/remote_retro.jsx
@@ -11,10 +11,6 @@ import Room from "./room"
 import ShareRetroLinkModal from "./share_retro_link_modal"
 
 export class RemoteRetro extends Component {
-  constructor(props) {
-    super(props)
-  }
-
   componentWillMount() {
     const { retroChannel, actions } = this.props
 

--- a/web/static/js/reducers/idea.js
+++ b/web/static/js/reducers/idea.js
@@ -1,5 +1,7 @@
 const idea = (state = [], action) => {
   switch (action.type) {
+    case "SET_INITIAL_STATE":
+      return action.initialState.ideas
     case "SET_IDEAS":
       return action.ideas
     case "ADD_IDEA":

--- a/web/static/js/reducers/idea.js
+++ b/web/static/js/reducers/idea.js
@@ -2,8 +2,6 @@ const idea = (state = [], action) => {
   switch (action.type) {
     case "SET_INITIAL_STATE":
       return action.initialState.ideas
-    case "SET_IDEAS":
-      return action.ideas
     case "ADD_IDEA":
       return [...state, action.idea]
     case "UPDATE_IDEA":

--- a/web/static/js/reducers/index.js
+++ b/web/static/js/reducers/index.js
@@ -3,11 +3,13 @@ import { combineReducers } from "redux"
 import user from "./user"
 import idea from "./idea"
 import stage from "./stage"
+import insertedAt from "./inserted_at"
 
 const rootReducer = combineReducers({
   user,
   idea,
   stage,
+  insertedAt,
 })
 
 export default rootReducer

--- a/web/static/js/reducers/index.js
+++ b/web/static/js/reducers/index.js
@@ -2,10 +2,12 @@ import { combineReducers } from "redux"
 
 import user from "./user"
 import idea from "./idea"
+import stage from "./stage"
 
 const rootReducer = combineReducers({
   user,
   idea,
+  stage,
 })
 
 export default rootReducer

--- a/web/static/js/reducers/inserted_at.js
+++ b/web/static/js/reducers/inserted_at.js
@@ -1,0 +1,10 @@
+const insertedAt = (state = null, action) => {
+  switch (action.type) {
+    case "SET_INITIAL_STATE":
+      return action.initialState.inserted_at
+    default:
+      return state
+  }
+}
+
+export default insertedAt

--- a/web/static/js/reducers/stage.js
+++ b/web/static/js/reducers/stage.js
@@ -1,5 +1,7 @@
 const stage = (state = "idea-generation", action) => {
   switch (action.type) {
+    case "SET_INITIAL_STATE":
+      return action.initialState.stage
     case "UPDATE_STAGE":
       return action.stage
     default:

--- a/web/static/js/reducers/stage.js
+++ b/web/static/js/reducers/stage.js
@@ -1,4 +1,4 @@
-const stage = (state = "idea-generation", action) => {
+const stage = (state = "", action) => {
   switch (action.type) {
     case "SET_INITIAL_STATE":
       return action.initialState.stage


### PR DESCRIPTION
This PR shifts the remainder of `RemoteRetro` component's local state (`stage` and `inserted_at`) to the redux store!

In doing this work, we introduce a new action, `SET_INITIAL_STATE`, that allowed two additional refactors: 
  1. make a single dispatch from the retroChannel's join callback
  1. delete the "SET_IDEAS" action and reducer case, as the case that called for it is now handled by `SET_INITIAL_STATE`, which handles setting `ideas`, `stage`, and `insertedAt` on the store