### PR TITLE
Fix remaining linter errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -62,5 +62,6 @@ module.exports = {
     "react/no-unused-prop-types": "off",
     "react/forbid-prop-types": "off",
     "jsx-a11y/no-static-element-interactions": 0,
+    "import/no-named-as-default": "off",
   }
 }

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,7 +1,8 @@
 {
   "rules": {
     "import/no-extraneous-dependencies": ["error", {"devDependencies": true, "optionalDependencies": false, "peerDependencies": false}],
-    "react/jsx-filename-extension": 0
+    "react/jsx-filename-extension": 0,
+    "no-unused-expressions": 0
   },
   "env": {
     "mocha": true

--- a/test/actions/retro_actions_test.js
+++ b/test/actions/retro_actions_test.js
@@ -21,5 +21,3 @@ describe("setInitialState", () => {
     })
   })
 })
-
-

--- a/test/components/remote_retro_test.js
+++ b/test/components/remote_retro_test.js
@@ -8,12 +8,13 @@ import RetroChannel from "../../web/static/js/services/retro_channel"
 describe("<RemoteRetro>", () => {
   describe("RetroChannel Events", () => {
     let retroChannel
-    let wrapper
+    let wrapper // eslint-disable-line no-unused-vars
     let actions
     let addIdeaSpy
     let deleteIdeaSpy
     let updateIdeaSpy
     let updateStageSpy
+    const now = Date.now().toString()
 
     beforeEach(() => {
       addIdeaSpy = spy()
@@ -37,6 +38,7 @@ describe("<RemoteRetro>", () => {
           actions={actions}
           userToken="userToken"
           retroChannel={retroChannel}
+          insertedAt={now}
         />
       )
     })
@@ -114,6 +116,7 @@ describe("<RemoteRetro>", () => {
               retroChannel={retroChannel}
               actions={actions}
               ideas={[]}
+              insertedAt={now}
             />
           )
         })

--- a/test/components/room_test.js
+++ b/test/components/room_test.js
@@ -39,7 +39,7 @@ describe("Room component", () => {
           />
         )
         const stageProgressionButton = roomComponent.find(StageProgressionButton)
-        expect(stageProgressionButton.prop("buttonDisabled")).to.be.true // eslint-disable-line no-unused-expressions
+        expect(stageProgressionButton.prop("buttonDisabled")).to.be.true
       })
     })
 
@@ -54,7 +54,7 @@ describe("Room component", () => {
           />
         )
         const stageProgressionButton = roomComponent.find(StageProgressionButton)
-        expect(stageProgressionButton.prop("buttonDisabled")).to.be.false // eslint-disable-line no-unused-expressions
+        expect(stageProgressionButton.prop("buttonDisabled")).to.be.false
       })
     })
   })

--- a/web/static/js/components/category_column.jsx
+++ b/web/static/js/components/category_column.jsx
@@ -13,7 +13,7 @@ const CategoryColumn = props => {
   return (
     <section className={`${category} ${styles.index} column`}>
       <div className={` ${styles.columnHead} ui center aligned basic segment`}>
-        <img src={`/images/${category}.svg`} height={iconHeight} width={iconHeight} alt={`${category}`} />
+        <img src={`/images/${category}.svg`} height={iconHeight} width={iconHeight} alt={category} />
         <p><strong>{category}</strong></p>
       </div>
       <div className={`ui fitted divider ${styles.divider}`} />

--- a/web/static/js/components/category_column.jsx
+++ b/web/static/js/components/category_column.jsx
@@ -13,7 +13,7 @@ const CategoryColumn = props => {
   return (
     <section className={`${category} ${styles.index} column`}>
       <div className={` ${styles.columnHead} ui center aligned basic segment`}>
-        <img src={`/images/${category}.svg`} height={iconHeight} width={iconHeight} />
+        <img src={`/images/${category}.svg`} height={iconHeight} width={iconHeight} alt={`${category}`} />
         <p><strong>{category}</strong></p>
       </div>
       <div className={`ui fitted divider ${styles.divider}`} />

--- a/web/static/js/components/remote_retro.jsx
+++ b/web/static/js/components/remote_retro.jsx
@@ -102,6 +102,8 @@ RemoteRetro.propTypes = {
   users: AppPropTypes.users,
   ideas: AppPropTypes.ideas,
   userToken: PropTypes.string.isRequired,
+  stage: PropTypes.string.isRequired,
+  insertedAt: PropTypes.string.isRequired,
 }
 
 RemoteRetro.defaultProps = {

--- a/web/static/js/components/share_retro_link_modal.jsx
+++ b/web/static/js/components/share_retro_link_modal.jsx
@@ -62,7 +62,7 @@ class ShareRetroLinkModal extends Component {
           </div>
           <div className="ui fluid input">
             <input
-              ref={input => this.input = input}
+              ref={input => { this.input = input }}
               readOnly
               className="ui input"
               type="text"

--- a/web/static/js/components/stage_progression_button.jsx
+++ b/web/static/js/components/stage_progression_button.jsx
@@ -86,6 +86,7 @@ StageProgressionButton.propTypes = {
 
 StageProgressionButton.defaultProps = {
   buttonDisabled: false,
+  config: null,
 }
 
 export default StageProgressionButton

--- a/web/static/js/reducers/user.js
+++ b/web/static/js/reducers/user.js
@@ -2,9 +2,10 @@ const user = (state = [], action) => {
   switch (action.type) {
     case "SET_USERS":
       return action.users
-    case "UPDATE_USER":
+    case "UPDATE_USER": {
       const { userToken, newAttributes } = action
       return state.map(user => (user.token === userToken ? { ...user, ...newAttributes } : user))
+    }
     default:
       return state
   }


### PR DESCRIPTION
```
remote_retro/test/actions/retro_actions_test.js
  24:1  error  Too many blank lines at the end of file. Max of 1 allowed  no-multiple-empty-lines

remote_retro/test/components/remote_retro_test.js
  11:9  error  'wrapper' is assigned a value but never used  no-unused-vars

remote_retro/test/components/stage_progression_button_test.js
  138:7  error  Expected an assignment or function call and instead saw an expression  no-unused-expressions

remote_retro/web/static/js/app.js
  8:8  error  Using exported name 'RemoteRetro' as identifier for default export  import/no-named-as-default

remote_retro/web/static/js/components/category_column.jsx
  16:9  error  img elements must have an alt prop, either with meaningful text, or an empty string for decorative images  jsx-a11y/img-has-alt

remote_retro/web/static/js/components/remote_retro.jsx
  33:9   warning  Unexpected alert                             no-alert
  80:52  error    'stage' is missing in props validation       react/prop-types
  80:59  error    'insertedAt' is missing in props validation  react/prop-types

remote_retro/web/static/js/components/share_retro_link_modal.jsx
  65:20  error  Arrow function should not return assignment  no-return-assign

remote_retro/web/static/js/components/stage_progression_button.jsx
  83:3  error  propType "config" is not required, but has no corresponding defaultProp declaration  react/require-default-props

remote_retro/web/static/js/reducers/user.js
  5:5  error  Unexpected lexical declaration in case block  no-case-declarations
```

This PR fixes everything except for the warning about the JS alert in the remote_retro.jsx file. 

Things to note:
* The no-named-as-default ESLint rule does not play well with Redux's pattern of `connect`ing classes and exporting the connected class as default (https://github.com/benmosher/eslint-plugin-import/issues/544), so I've turned this rule off for all JS files.
* The no-unused-expressions rule doesn't play well with Mocha (https://github.com/eslint/eslint/issues/2102) so I've turned this rule off for test files.