### PR TITLE
Bugfix: Allow insertedAt to be null in RemoteRetro component

### DIFF
--- a/web/static/js/components/remote_retro.jsx
+++ b/web/static/js/components/remote_retro.jsx
@@ -103,12 +103,13 @@ RemoteRetro.propTypes = {
   ideas: AppPropTypes.ideas,
   userToken: PropTypes.string.isRequired,
   stage: PropTypes.string.isRequired,
-  insertedAt: PropTypes.string.isRequired,
+  insertedAt: PropTypes.string,
 }
 
 RemoteRetro.defaultProps = {
   users: [],
   ideas: [],
+  insertedAt: null,
 }
 
 const mapStateToProps = state => ({


### PR DESCRIPTION
In attempting to fix a linting issue, I set the `insertedAt` prop as required, but it turns out that it is sometimes null. Defaulting it to null allows it to function as normal and placates the linter.