### PR TITLE
Bugfix: Fix the check for user typing

### DIFF
--- a/web/static/js/components/remote_retro.jsx
+++ b/web/static/js/components/remote_retro.jsx
@@ -39,11 +39,10 @@ export class RemoteRetro extends Component {
       }
     })
 
-    retroChannel.on("user_typing_idea", payload => {
-      const user = this.props.users.find(user => user.token === payload.userToken)
-      actions.updateUser(payload.userToken, { is_typing: true, last_typed: Date.now() })
-      UserActivity.checkIfDoneTyping(user, () => {
-        actions.updateUser(user.token, { is_typing: false })
+    retroChannel.on("user_typing_idea", ({ userToken }) => {
+      actions.updateUser(userToken, { is_typing: true, last_typed: Date.now() })
+      UserActivity.checkIfDoneTyping(this, userToken, () => {
+        actions.updateUser(userToken, { is_typing: false })
       })
     })
 

--- a/web/static/js/services/user_activity.js
+++ b/web/static/js/services/user_activity.js
@@ -1,6 +1,8 @@
 class UserActivity {
-  static checkIfDoneTyping(user, done) {
+  static checkIfDoneTyping(channel, userToken, done) {
     const interval = setInterval(() => {
+      const { users } = channel.props
+      const user = users.find(user => user.token === userToken)
       const noNewTypingEventsReceived = (Date.now() - user.last_typed) > 650
       if (noNewTypingEventsReceived) {
         clearInterval(interval)


### PR DESCRIPTION
After my refactor in #176, the dots are starting and stopping erratically when someone types. This stops it doing that. 

I'd wanted not to have to pass in the entire `RetroChannel` object, but because the props change within the channel, just passing in the props or the users isn't sufficient and they need to be accessed anew within the interval. 