### PR TITLE
Change scroll to auto

### DIFF
--- a/web/static/js/components/css_modules/category_column.css
+++ b/web/static/js/components/css_modules/category_column.css
@@ -10,6 +10,6 @@
   list-style: none;
   padding-left: 0;
   margin-top: 0;
-  overflow-y: scroll;
+  overflow-y: auto;
   height: 44vh;
 }


### PR DESCRIPTION
This fixes the scrolling on the retro page so that the scrollbar only appears when a list has become too long for its container.  Otherwise, no scroll appears.  Before this change, a scrollbar would always appear.