### PR TITLE
Add link to feedback survey to action item distribution alert

### DIFF
--- a/web/static/js/configs/stage_configs.jsx
+++ b/web/static/js/configs/stage_configs.jsx
@@ -1,3 +1,5 @@
+import React from "react"
+
 export default {
   "prime-directive": {
     alert: null,
@@ -29,7 +31,12 @@ export default {
   "action-item-distribution": {
     alert: {
       headerText: "Action Items Distributed",
-      bodyText: "The facilitator has distributed this retro's action items. You will receive an email breakdown shortly!",
+      bodyText: <div>
+        <p>The facilitator has distributed this retro's action items.
+          You will receive an email breakdown shortly!</p>
+        <p>Thank you for using Remote Retro!
+          Please click <a href="https://www.surveymonkey.com/r/JKT9FXM" target="_blank" rel="noopener noreferrer">here</a> to give us feedback on your experience.</p>
+      </div>,
     },
     confirmationMessage: null,
     nextStage: null,


### PR DESCRIPTION
__Description of Change(s) Introduced:__ I created a Survey Monkey survey and added a link to it to the action item distribution alert. 

The survey results can be seen [here](https://www.surveymonkey.com/analyze/Sm5V2nM7ZHiVzOs34rhW81bWvjEWSpadfDicDUlGZF8_3D
).
username: remoteretro
pw: r3moter3tro8!