### PR TITLE
Change condition for disabling the stage progression button

### DIFF
--- a/test/components/idea_generation_lower_third_test.js
+++ b/test/components/idea_generation_lower_third_test.js
@@ -29,6 +29,35 @@ describe("IdeaGenerationLowerThird component", () => {
       })
     })
 
+    context("and there are no ideas during the idea-generation stage", () => {
+      it("renders a disabled <StageProgressionButton>", () => {
+        const lowerThird = shallow(
+          <IdeaGenerationLowerThird
+            {...defaultProps}
+            currentUser={facilitatorUser}
+            stage="idea-generation"
+          />
+        )
+        const stageProgressionButton = lowerThird.find(StageProgressionButton)
+        expect(stageProgressionButton.prop("buttonDisabled")).to.be.true
+      })
+    })
+
+    context("and there are ideas during the idea-generation stage", () => {
+      it("renders an enabled <StageProgressionButton>", () => {
+        const lowerThird = shallow(
+          <IdeaGenerationLowerThird
+            {...defaultProps}
+            currentUser={facilitatorUser}
+            stage="idea-generation"
+            ideas={[{ category: "happy" }]}
+          />
+        )
+        const stageProgressionButton = lowerThird.find(StageProgressionButton)
+        expect(stageProgressionButton.prop("buttonDisabled")).to.be.false
+      })
+    })
+
     context("and there are no action items during the action-items stage", () => {
       it("renders a disabled <StageProgressionButton>", () => {
         const lowerThird = shallow(

--- a/web/static/js/components/idea_generation_lower_third.jsx
+++ b/web/static/js/components/idea_generation_lower_third.jsx
@@ -12,10 +12,12 @@ const IdeaGenerationLowerThird = props => {
 
   const isFacilitator = currentUser.is_facilitator
   const stageConfig = stageConfigs[stage]
-  const showActionItem = stage !== "idea-generation"
+  const showActionItem = ["action-items", "action-item-distribution"].includes(stage)
 
-  function wereActionItemsSubmitted() {
-    return showActionItem && !ideas.some(idea => idea.category === "action-item")
+  function progressionDisabled() {
+    const noIdeasCreated = stage === "idea-generation" && !ideas.length
+    const noActionItemsCreated = stage === "action-items" && !ideas.some(idea => idea.category === "action-item")
+    return noIdeasCreated || noActionItemsCreated
   }
 
   return (
@@ -28,7 +30,7 @@ const IdeaGenerationLowerThird = props => {
           <StageProgressionButton
             {...props}
             config={stageConfig}
-            buttonDisabled={wereActionItemsSubmitted()}
+            buttonDisabled={progressionDisabled()}
           />
         }
       </div>


### PR DESCRIPTION
__Description of Change(s) Introduced:__ Previously the stageProgressionButton was only disabled when there were no action items. This bugfix makes it so that it is also disabled when there are no ideas.
