### PR TITLE
Add prop and conditionally disable button when not in voting stage

### DIFF
--- a/test/components/idea_controls_test.js
+++ b/test/components/idea_controls_test.js
@@ -10,6 +10,7 @@ describe("<IdeaControls />", () => {
   const mockUser = { id: 2, is_facilitator: true }
   const ideaGenerationStage = "idea-generation"
   const votingStage = "voting"
+  const actionItemsStage = "action-items"
 
   describe("on click of the removal icon", () => {
     it("pushes an `delete_idea` event to the retro channel, passing the given idea's id", () => {
@@ -239,6 +240,24 @@ describe("<IdeaControls />", () => {
          )
 
         expect(wrapper.find(VoteCounter)).to.have.length(0)
+      })
+    })
+
+    context("after entering action-items stage", () => {
+      it("renders a disabled VoteCounter for display purposes", () => {
+        const retroChannel = { on: () => {}, push: sinon.spy() }
+        const currentUser = { id: 1, is_facilitator: false }
+
+        const wrapper = shallow(
+          <IdeaControls
+            idea={idea}
+            retroChannel={retroChannel}
+            currentUser={currentUser}
+            stage={actionItemsStage}
+          />
+         )
+
+        expect(wrapper.find(VoteCounter).prop("buttonDisabled")).to.be.true
       })
     })
   })

--- a/test/components/vote_counter_test.js
+++ b/test/components/vote_counter_test.js
@@ -28,6 +28,58 @@ describe("VoteCounter", () => {
     expect(label.text()).to.equal(idea.vote_count.toString())
   })
 
+  context("when buttonDisabled is false", () => {
+    let voteCounter
+    let button
+    let label
+    beforeEach(() => {
+      voteCounter = shallow(
+        <VoteCounter
+          retroChannel={{}}
+          idea={idea}
+          buttonDisabled={false}
+        />
+      )
+      button = voteCounter.find("button")
+      label = voteCounter.find("a")
+    })
+
+    it("renders a green button and label", () => {
+      expect(button.hasClass("green")).to.be.true
+      expect(label.hasClass("green")).to.be.true
+    })
+
+    it("renders an enabled button", () => {
+      expect(button.prop("disabled")).to.be.false
+    })
+  })
+
+  context("when buttonDisabled is true", () => {
+    let voteCounter
+    let button
+    let label
+    beforeEach(() => {
+      voteCounter = shallow(
+        <VoteCounter
+          retroChannel={{}}
+          idea={idea}
+          buttonDisabled
+        />
+      )
+      button = voteCounter.find("button")
+      label = voteCounter.find("a")
+    })
+
+    it("renders a grey button and label", () => {
+      expect(button.hasClass("grey")).to.be.true
+      expect(label.hasClass("grey")).to.be.true
+    })
+
+    it("renders an disabled button", () => {
+      expect(button.prop("disabled")).to.be.true
+    })
+  })
+
   describe("handleClick", () => {
     it("calls retroChannel.push with 'submit_vote' and the idea's id", () => {
       const pushSpy = spy()

--- a/test/components/vote_counter_test.js
+++ b/test/components/vote_counter_test.js
@@ -28,36 +28,8 @@ describe("VoteCounter", () => {
     expect(label.text()).to.equal(idea.vote_count.toString())
   })
 
-  context("when buttonDisabled is false", () => {
-    let voteCounter
-    let button
-    let label
-    beforeEach(() => {
-      voteCounter = shallow(
-        <VoteCounter
-          retroChannel={{}}
-          idea={idea}
-          buttonDisabled={false}
-        />
-      )
-      button = voteCounter.find("button")
-      label = voteCounter.find("a")
-    })
-
-    it("renders a green button and label", () => {
-      expect(button.hasClass("green")).to.be.true
-      expect(label.hasClass("green")).to.be.true
-    })
-
-    it("renders an enabled button", () => {
-      expect(button.prop("disabled")).to.be.false
-    })
-  })
-
   context("when buttonDisabled is true", () => {
     let voteCounter
-    let button
-    let label
     beforeEach(() => {
       voteCounter = shallow(
         <VoteCounter
@@ -66,17 +38,10 @@ describe("VoteCounter", () => {
           buttonDisabled
         />
       )
-      button = voteCounter.find("button")
-      label = voteCounter.find("a")
     })
 
-    it("renders a grey button and label", () => {
-      expect(button.hasClass("grey")).to.be.true
-      expect(label.hasClass("grey")).to.be.true
-    })
-
-    it("renders an disabled button", () => {
-      expect(button.prop("disabled")).to.be.true
+    it("renders a disabled VoteCounter", () => {
+      expect(voteCounter.hasClass("disabled")).to.be.true
     })
   })
 

--- a/web/static/js/components/css_modules/vote_counter.css
+++ b/web/static/js/components/css_modules/vote_counter.css
@@ -13,8 +13,4 @@
     padding: 0.5rem;
     cursor: default;
   }
-
-  .disabled-button {
-    cursor: default !important;
-  }
 }

--- a/web/static/js/components/css_modules/vote_counter.css
+++ b/web/static/js/components/css_modules/vote_counter.css
@@ -13,4 +13,8 @@
     padding: 0.5rem;
     cursor: default;
   }
+
+  .disabled-button {
+    cursor: default !important;
+  }
 }

--- a/web/static/js/components/idea_controls.jsx
+++ b/web/static/js/components/idea_controls.jsx
@@ -24,7 +24,11 @@ const IdeaControls = props => {
   function renderIcons() {
     if (stage !== "idea-generation" && category !== "action-item") {
       return (
-        <VoteCounter retroChannel={retroChannel} idea={idea} />
+        <VoteCounter
+          retroChannel={retroChannel}
+          idea={idea}
+          buttonDisabled={stage !== "voting"}
+        />
       )
     }
     if (currentUser.is_facilitator) {

--- a/web/static/js/components/vote_counter.jsx
+++ b/web/static/js/components/vote_counter.jsx
@@ -16,30 +16,21 @@ class VoteCounter extends React.Component {
 
   render() {
     const { buttonDisabled } = this.props
-    const buttonClasses = classNames(`ui button ${styles.voteButton}`, {
-      green: !buttonDisabled,
-      grey: buttonDisabled,
-      [`${styles.disabledButton}`]: buttonDisabled,
-    })
-    const labelClasses = classNames(`ui basic left pointing label ${styles.voteCount}`, {
-      green: !buttonDisabled,
-      grey: buttonDisabled,
-    })
-    const buttonWrapperClasses = classNames("ui labeled right floated button", {
-      [`${styles.disabledButton}`]: buttonDisabled,
-    })
     const { vote_count: voteCount } = this.props.idea
+    const counterClasses = classNames("ui labeled right floated button", {
+      disabled: buttonDisabled,
+    })
 
     return (
-      <div className={buttonWrapperClasses}>
+      <div className={counterClasses}>
         <button
-          className={buttonClasses}
+          className={`ui green button ${styles.voteButton}`}
           onClick={this.handleClick}
           disabled={buttonDisabled}
         >
           Vote
         </button>
-        <a className={labelClasses}>
+        <a className={`ui basic green label ${styles.voteCount}`}>
           {voteCount}
         </a>
       </div>

--- a/web/static/js/components/vote_counter.jsx
+++ b/web/static/js/components/vote_counter.jsx
@@ -1,4 +1,5 @@
-import React from "react"
+import React, { PropTypes } from "react"
+import classNames from "classnames"
 import * as AppPropTypes from "../prop_types"
 import styles from "./css_modules/vote_counter.css"
 
@@ -14,14 +15,31 @@ class VoteCounter extends React.Component {
   }
 
   render() {
+    const { buttonDisabled } = this.props
+    const buttonClasses = classNames(`ui button ${styles.voteButton}`, {
+      green: !buttonDisabled,
+      grey: buttonDisabled,
+      [`${styles.disabledButton}`]: buttonDisabled,
+    })
+    const labelClasses = classNames(`ui basic left pointing label ${styles.voteCount}`, {
+      green: !buttonDisabled,
+      grey: buttonDisabled,
+    })
+    const buttonWrapperClasses = classNames("ui labeled right floated button", {
+      [`${styles.disabledButton}`]: buttonDisabled,
+    })
     const { vote_count: voteCount } = this.props.idea
 
     return (
-      <div className="ui labeled right floated button">
-        <button className={`ui green button ${styles.voteButton}`} onClick={this.handleClick}>
+      <div className={buttonWrapperClasses}>
+        <button
+          className={buttonClasses}
+          onClick={this.handleClick}
+          disabled={buttonDisabled}
+        >
           Vote
         </button>
-        <a className={`ui basic green label ${styles.voteCount}`}>
+        <a className={labelClasses}>
           {voteCount}
         </a>
       </div>
@@ -29,9 +47,14 @@ class VoteCounter extends React.Component {
   }
 }
 
+VoteCounter.defaultProps = {
+  buttonDisabled: false,
+}
+
 VoteCounter.propTypes = {
   retroChannel: AppPropTypes.retroChannel.isRequired,
   idea: AppPropTypes.idea.isRequired,
+  buttonDisabled: PropTypes.bool,
 }
 
 export default VoteCounter


### PR DESCRIPTION
 __Description of Change(s) Introduced:__ using the classnames library, conditionally style the voting button so that it is clear that it is disabled when not in the voting stage. Also, actually disable the button. 

I couldn't get the cursor appearance to go back to default for the disabled button. Despite adding in the CSS for it, for some reason the div that wraps the button and label seem to ignore it. @vanderhoop do you have any ideas about what might be going on here?

__Relevant github Issue:__ 

#245 
