### PR TITLE
Feature/link vote to user

### DIFF
--- a/priv/repo/migrations/20170816203847_add_vote_count_to_participation.exs
+++ b/priv/repo/migrations/20170816203847_add_vote_count_to_participation.exs
@@ -1,0 +1,9 @@
+defmodule RemoteRetro.Repo.Migrations.AddVoteCountToParticipation do
+  use Ecto.Migration
+
+  def change do
+    alter table(:participations) do
+      add :vote_count, :integer, default: 0, null: false
+    end
+  end
+end

--- a/test/channels/retro_channel_test.exs
+++ b/test/channels/retro_channel_test.exs
@@ -2,7 +2,7 @@ defmodule RemoteRetro.RetroChannelTest do
   use RemoteRetro.ChannelCase, async: false
   use Bamboo.Test, shared: true
 
-  alias RemoteRetro.{RetroChannel, Repo, Idea, Presence, Retro}
+  alias RemoteRetro.{RetroChannel, Repo, Idea, Presence, Retro, Participation}
 
   @mock_user Application.get_env(:remote_retro, :mock_user)
 
@@ -174,27 +174,61 @@ defmodule RemoteRetro.RetroChannelTest do
   end
 
   describe "pushing a `submit_vote` event to the socket" do
-    setup [:persist_user_for_retro, :persist_idea_for_retro, :join_the_retro_channel]
+    setup [:persist_user_for_retro, :persist_idea_for_retro, :persist_participation_for_retro, :join_the_retro_channel]
 
     @tag user: @mock_user
     @tag idea: %Idea{category: "sad", body: "JavaScript"}
-    test "results in the broadcast of the voted on idea to all connected clients", %{socket: socket, idea: idea} do
+    test "if it fails to find the participation it sends an error message", %{socket: socket, idea: idea} do
+      push(socket, "submit_vote", %{ideaId: idea.id, userId: 9999})
+
+      assert_broadcast("vote_submitted", %{error: "no participation found"})
+    end
+
+    @tag user: @mock_user
+    @tag idea: %Idea{category: "sad", body: "JavaScript"}
+    test "if it fails to find the idea it sends an error message", %{socket: socket, user: user} do
+      push(socket, "submit_vote", %{ideaId: 8888, userId: user.id})
+
+      assert_broadcast("vote_submitted", %{error: "no idea found"})
+    end
+
+    @tag user: @mock_user
+    @tag idea: %Idea{category: "sad", body: "JavaScript"}
+    test "if it fails to find the participation and idea it sends an error message", %{socket: socket} do
+      push(socket, "submit_vote", %{ideaId: 8888, userId: 9999})
+
+      assert_broadcast("vote_submitted", %{error: "no participation or idea found"})
+    end
+
+    @tag user: @mock_user
+    @tag idea: %Idea{category: "sad", body: "JavaScript"}
+    test "results in the broadcast of the voted on idea to all connected clients", %{socket: socket, idea: idea, user: user} do
       idea_id = idea.id
-      push(socket, "submit_vote", %{id: idea_id})
+      push(socket, "submit_vote", %{ideaId: idea_id, userId: user.id})
 
       assert_broadcast("vote_submitted", %{body: "JavaScript", id: ^idea_id, vote_count: 1})
     end
 
-
     @tag user: @mock_user
     @tag idea: %Idea{category: "sad", body: "doggone keeper"}
-    test "results in the idea being updated in the database", %{socket: socket, idea: idea} do
+    test "results in the idea being updated in the database", %{socket: socket, idea: idea, user: user} do
       idea_id = idea.id
-      push(socket, "submit_vote", %{id: idea_id})
+      push(socket, "submit_vote", %{ideaId: idea_id, userId: user.id})
 
       :timer.sleep(50)
       idea = Repo.get!(Idea, idea_id)
-      assert idea.vote_count == 1 
+      assert idea.vote_count == 1
+    end
+
+    @tag user: @mock_user
+    @tag idea: %Idea{category: "sad", body: "doggone keeper"}
+    test "results in the participation being updated in the database", %{socket: socket, idea: idea, user: user, participation: participation} do
+      idea_id = idea.id
+      push(socket, "submit_vote", %{ideaId: idea_id, userId: user.id})
+
+      :timer.sleep(50)
+      participation = Repo.get!(Participation, participation.id)
+      assert participation.vote_count == 1
     end
   end
 end

--- a/test/channels/retro_channel_test.exs
+++ b/test/channels/retro_channel_test.exs
@@ -178,30 +178,6 @@ defmodule RemoteRetro.RetroChannelTest do
 
     @tag user: @mock_user
     @tag idea: %Idea{category: "sad", body: "JavaScript"}
-    test "if it fails to find the participation it sends an error message", %{socket: socket, idea: idea} do
-      push(socket, "submit_vote", %{ideaId: idea.id, userId: 9999})
-
-      assert_broadcast("vote_submitted", %{error: "no participation found"})
-    end
-
-    @tag user: @mock_user
-    @tag idea: %Idea{category: "sad", body: "JavaScript"}
-    test "if it fails to find the idea it sends an error message", %{socket: socket, user: user} do
-      push(socket, "submit_vote", %{ideaId: 8888, userId: user.id})
-
-      assert_broadcast("vote_submitted", %{error: "no idea found"})
-    end
-
-    @tag user: @mock_user
-    @tag idea: %Idea{category: "sad", body: "JavaScript"}
-    test "if it fails to find the participation and idea it sends an error message", %{socket: socket} do
-      push(socket, "submit_vote", %{ideaId: 8888, userId: 9999})
-
-      assert_broadcast("vote_submitted", %{error: "no participation or idea found"})
-    end
-
-    @tag user: @mock_user
-    @tag idea: %Idea{category: "sad", body: "JavaScript"}
     test "results in the broadcast of the voted on idea to all connected clients", %{socket: socket, idea: idea, user: user} do
       idea_id = idea.id
       push(socket, "submit_vote", %{ideaId: idea_id, userId: user.id})

--- a/test/components/vote_counter_test.js
+++ b/test/components/vote_counter_test.js
@@ -14,12 +14,14 @@ describe("VoteCounter", () => {
     },
     vote_count: 0,
   }
+  const mockUser = { id: 55 }
 
   it("renders an anchor tag that contains the vote count of the idea", () => {
     const voteCounter = shallow(
       <VoteCounter
         retroChannel={{}}
         idea={idea}
+        currentUser={mockUser}
       />
     )
     const label = voteCounter.find("a")
@@ -46,7 +48,7 @@ describe("VoteCounter", () => {
   })
 
   describe("handleClick", () => {
-    it("calls retroChannel.push with 'submit_vote' and the idea's id", () => {
+    it("calls retroChannel.push with 'submit_vote', the idea's id, and the user id", () => {
       const pushSpy = spy()
       const retroChannelMock = {
         push: pushSpy,
@@ -55,11 +57,12 @@ describe("VoteCounter", () => {
         <VoteCounter
           retroChannel={retroChannelMock}
           idea={idea}
+          currentUser={mockUser}
         />
       )
       voteCounter.instance().handleClick()
 
-      expect(pushSpy.calledWith("submit_vote", { id: idea.id })).to.be.true
+      expect(pushSpy.calledWith("submit_vote", { ideaId: idea.id, userId: mockUser.id })).to.be.true
     })
   })
 })

--- a/test/components/vote_counter_test.js
+++ b/test/components/vote_counter_test.js
@@ -38,6 +38,7 @@ describe("VoteCounter", () => {
           retroChannel={{}}
           idea={idea}
           buttonDisabled
+          currentUser={mockUser}
         />
       )
     })

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -1,6 +1,6 @@
 defmodule RemoteRetro.TestHelpers do
   use Wallaby.DSL
-  alias RemoteRetro.{Repo, User}
+  alias RemoteRetro.{Repo, User, Participation}
 
   def persist_idea_for_retro(context) do
     %{idea: idea, retro: retro, user: user} = context
@@ -19,6 +19,15 @@ defmodule RemoteRetro.TestHelpers do
       |> Repo.insert!
 
     Map.put(context, :user, user)
+  end
+
+  def persist_participation_for_retro(context) do
+    %{user: user, retro: retro} = context
+    participation =
+      Participation.changeset(%Participation{}, %{user_id: user.id, retro_id: retro.id})
+      |> Repo.insert!
+
+    Map.put(context, :participation, participation)
   end
 
   def new_browser_session(metadata \\ %{}) do

--- a/web/channels/retro_channel.ex
+++ b/web/channels/retro_channel.ex
@@ -82,25 +82,13 @@ defmodule RemoteRetro.RetroChannel do
     idea_query = from i in Idea, where: i.id == ^idea_id
     participation_query = from p in Participation, where: p.user_id == ^user_id and p.retro_id == ^retro_id
 
-    result =
+    {:ok, %{idea: {1, [updated_idea]}, participation: {1, [_updated_participation]}}} =
       Multi.new
       |> Multi.update_all(:idea, idea_query, [inc: [vote_count: 1]], returning: true)
       |> Multi.update_all(:participation, participation_query, [inc: [vote_count: 1]], returning: true)
       |> Repo.transaction
 
-    result_to_send =
-      case result do
-        {:ok, %{idea: {_idea_row_count, [updated_idea]}, participation: {_particip_row_count, [_updated_participation]}}} ->
-          updated_idea
-        {:ok, %{idea: {0, []}, participation: {0, []}}} ->
-          %{error: "no participation or idea found"}
-        {:ok, %{idea: {1, [_updated_idea]}, participation: {0, []}}} ->
-          %{error: "no participation found"}
-        {:ok, %{idea: {0, []}, participation: {1, [_updated_participation]}}} ->
-          %{error: "no idea found"}
-      end
-
-    broadcast! socket, "vote_submitted", result_to_send
+    broadcast! socket, "vote_submitted", updated_idea
     {:noreply, socket}
   end
 

--- a/web/models/participation.ex
+++ b/web/models/participation.ex
@@ -4,16 +4,17 @@ defmodule RemoteRetro.Participation do
   schema "participations" do
     belongs_to :user, RemoteRetro.User
     belongs_to :retro, RemoteRetro.Retro, type: Ecto.UUID
+    field :vote_count, :integer, default: 0
 
     timestamps(type: :utc_datetime)
   end
 
-  @required_fields [:user_id, :retro_id]
+  @allowed_fields [:user_id, :retro_id, :vote_count]
 
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, @required_fields)
+    |> cast(params, @allowed_fields)
     |> unique_constraint(:user_id_retro_id, name: :participations_user_id_retro_id_index)
-    |> validate_required(@required_fields)
+    |> validate_required([:user_id, :retro_id])
   end
 end

--- a/web/static/js/components/idea_controls.jsx
+++ b/web/static/js/components/idea_controls.jsx
@@ -28,6 +28,7 @@ const IdeaControls = props => {
           retroChannel={retroChannel}
           idea={idea}
           buttonDisabled={stage !== "voting"}
+          currentUser={currentUser}
         />
       )
     }

--- a/web/static/js/components/vote_counter.jsx
+++ b/web/static/js/components/vote_counter.jsx
@@ -10,8 +10,8 @@ class VoteCounter extends React.Component {
   }
 
   handleClick() {
-    const { idea, retroChannel } = this.props
-    retroChannel.push("submit_vote", { id: idea.id })
+    const { idea, retroChannel, currentUser } = this.props
+    retroChannel.push("submit_vote", { ideaId: idea.id, userId: currentUser.id })
   }
 
   render() {
@@ -46,6 +46,7 @@ VoteCounter.propTypes = {
   retroChannel: AppPropTypes.retroChannel.isRequired,
   idea: AppPropTypes.idea.isRequired,
   buttonDisabled: PropTypes.bool,
+  currentUser: AppPropTypes.user.isRequired,
 }
 
 export default VoteCounter


### PR DESCRIPTION
__Description of Change(s) Introduced:__ 

Added a migration to add vote_count field to the participations table, and updated the corresponding model. I updated the submit_vote callback to use a transaction to update both the idea and the participation with the incremented vote count. 

The update_all method doesn't ever return an error, so instead I check if the updated row count is 0 for either idea or participation or both. I'm not completely sure how to handle these cases, but returning an error message seemed like a good idea. Do you know of a better way to handle this?

__Description of Testing Applied:__ Added tests for retro_channel.ex and updated the tests for VoteCounter component

__Relevant github Issue:__

- #235 
