### PR TITLE
Feature/contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,27 +12,22 @@ The best way to contribute is to take a look at our current backlog and work on 
 Please read our [Code of Conduct](https://github.com/stride-nyc/remote_retro/blob/master/CODE_OF_CONDUCT.md) before contributing.
 
 # First time contributing?
-Unsure where to begin contributing to Remote Retro? You can start by looking through issues that have the "beginner-friendly" or "help wanted" label.
+Unsure where to begin contributing to Remote Retro? You can start by looking through [issues](https://github.com/stride-nyc/remote_retro/issues) that have the "beginner-friendly" or "help wanted" label.
 
 # Getting started
-### Give them a quick walkthrough of how to submit a contribution.
-Please see the [Dev Environment Setup](https://github.com/stride-nyc/remote_retro#dev-environment-setup) and [Tests](https://github.com/stride-nyc/remote_retro#tests) sections of the Readme.
+* Before you start coding, please see the [Dev Environment Setup](https://github.com/stride-nyc/remote_retro#dev-environment-setup) and [Tests](https://github.com/stride-nyc/remote_retro#tests) sections of the Readme for information about getting set up and running the tests.
+* We require all contributors to sign a Contributor License Agreement before contributing. You will be prompted to electronically sign the individual CLA when you make a pull request.
+  - The individual CLA can be viewed [here](https://gist.github.com/qlaire/cfcc3a2b9ab28f3c97716e4040afe578)
+  - The corporate CLA can be viewed [here](https://gist.github.com/qlaire/c6b31ad2ba9489e75f6c810be466e7c6)
+* Please see the [Project Management](https://github.com/stride-nyc/remote_retro#project-management) section to see how to view Remote Retro's current feature pipeline.
 
-* Let them know if they need to sign a CLA, agree to a DCO, or get any other legal stuff out of the way
-* If tests are required for contributions, let them know, and explain how to run the tests
-* If you use anything other than GitHub to manage issues (ex. JIRA or Trac), let them know which tools they’ll need to contribute
-
-For something that is bigger than a one or two line fix:
+Once you're ready to start coding:
 
 1. Create your own fork of the code
 2. Do the changes in your fork
 3. If you like the change and think the project could use it:
     * Be sure you have followed the code style for the project.
-    * Sign the Contributor License Agreement, CLA, with the jQuery Foundation.
-    * Note the jQuery Foundation Code of Conduct.
-    * Send a pull request indicating that you have a CLA on file.
-
-[source: [Requirejs](http://requirejs.org/docs/contributing.html)] **Need more inspiration?** [1] [Active Admin](https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md#1-where-do-i-go-from-here) [2] [Node.js](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#code-contributions) [3] [Ember.js](https://github.com/emberjs/ember.js/blob/master/CONTRIBUTING.md#pull-requests)
+    * Make a pull request, and be sure to fill out the information in the template.
 
 
 # How to report a bug
@@ -43,21 +38,14 @@ In order to determine whether you are dealing with a security issue, ask yoursel
 * Can I access something that's not mine, or something I shouldn't have access to?
 * Can I disable something for other people?
 
-### How to file a bug report.
+### For non-security issues
 Please open an issue and use the template provided. Please add the "Bug" label.
 
 # How to suggest a feature or enhancement
 Before suggesting a feature, please read through the [Roadmap to MVP](https://github.com/stride-nyc/remote_retro#roadmap-to-mvp) and check the backlog to make sure that the story doesn't exist already. Once you're ready to suggest the feature or enhancement, open an issue and use the provided template. Please also add the "feature request" label.
 
 # Code review process
-After you submit your pull request, it will be reviewed within 5 business days and we will give you feedback on any needed changes.
-After feedback has been given we expect responses within two weeks. After two weeks we may close the pull request if it isn't showing any activity.
-
-# Community
-If there are other channels you use besides GitHub to discuss contributions, mention them here. You can also list the author, maintainers, and/or contributors here, or set expectations for response time.
-
-> You can chat with the core team on https://gitter.im/cucumber/cucumber. We try to have office hours on Fridays.
+After you submit your pull request, it will be reviewed within 10 business days and we will give you feedback on any needed changes. After feedback has been given we expect responses within two weeks. After two weeks we may close the pull request if it isn't showing any activity.
 
 # Code Style
-ESLint is used for checking JavaScript code style. It is also useful for avoiding some errors. Please use indentation of 2 spaces, and no semicolons.
-Please use ES2015.
+ESLint is used for checking JavaScript code style. It is also useful for avoiding some errors. Please use indentation of 2 spaces, and no semicolons. Please use ES2015.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,63 @@
+# Introduction
+
+### Greetings, contributor!
+
+Thank you for considering contributing to Remote Retro. We're happy to have you!
+
+### Types of contributions we're looking for
+
+The best way to contribute is to take a look at our current backlog and work on a story that you're most excited about. Please take a look at the [Project Management](https://github.com/stride-nyc/remote_retro#project-management) section of our Readme for viewing the backlog. Bug fixes and documentation improvements are also welcome.
+
+# Code of Conduct
+Please read our [Code of Conduct](https://github.com/stride-nyc/remote_retro/blob/master/CODE_OF_CONDUCT.md) before contributing.
+
+# First time contributing?
+Unsure where to begin contributing to Remote Retro? You can start by looking through issues that have the "beginner-friendly" or "help wanted" label.
+
+# Getting started
+### Give them a quick walkthrough of how to submit a contribution.
+Please see the [Dev Environment Setup](https://github.com/stride-nyc/remote_retro#dev-environment-setup) and [Tests](https://github.com/stride-nyc/remote_retro#tests) sections of the Readme.
+
+* Let them know if they need to sign a CLA, agree to a DCO, or get any other legal stuff out of the way
+* If tests are required for contributions, let them know, and explain how to run the tests
+* If you use anything other than GitHub to manage issues (ex. JIRA or Trac), let them know which tools they’ll need to contribute
+
+For something that is bigger than a one or two line fix:
+
+1. Create your own fork of the code
+2. Do the changes in your fork
+3. If you like the change and think the project could use it:
+    * Be sure you have followed the code style for the project.
+    * Sign the Contributor License Agreement, CLA, with the jQuery Foundation.
+    * Note the jQuery Foundation Code of Conduct.
+    * Send a pull request indicating that you have a CLA on file.
+
+[source: [Requirejs](http://requirejs.org/docs/contributing.html)] **Need more inspiration?** [1] [Active Admin](https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md#1-where-do-i-go-from-here) [2] [Node.js](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#code-contributions) [3] [Ember.js](https://github.com/emberjs/ember.js/blob/master/CONTRIBUTING.md#pull-requests)
+
+
+# How to report a bug
+### Security issues
+If you find a security vulnerability, do NOT open an issue. Email XXXX instead.
+
+In order to determine whether you are dealing with a security issue, ask yourself these two questions:
+* Can I access something that's not mine, or something I shouldn't have access to?
+* Can I disable something for other people?
+
+### How to file a bug report.
+Please open an issue and use the template provided. Please add the "Bug" label.
+
+# How to suggest a feature or enhancement
+Before suggesting a feature, please read through the [Roadmap to MVP](https://github.com/stride-nyc/remote_retro#roadmap-to-mvp) and check the backlog to make sure that the story doesn't exist already. Once you're ready to suggest the feature or enhancement, open an issue and use the provided template. Please also add the "feature request" label.
+
+# Code review process
+After you submit your pull request, it will be reviewed within 5 business days and we will give you feedback on any needed changes.
+After feedback has been given we expect responses within two weeks. After two weeks we may close the pull request if it isn't showing any activity.
+
+# Community
+If there are other channels you use besides GitHub to discuss contributions, mention them here. You can also list the author, maintainers, and/or contributors here, or set expectations for response time.
+
+> You can chat with the core team on https://gitter.im/cucumber/cucumber. We try to have office hours on Fridays.
+
+# Code Style
+ESLint is used for checking JavaScript code style. It is also useful for avoiding some errors. Please use indentation of 2 spaces, and no semicolons.
+Please use ES2015.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Unsure where to begin contributing to Remote Retro? You can start by looking thr
 Once you're ready to start coding:
 
 1. Create your own fork of the code
-2. Do the changes in your fork
+2. Make the necessary changes in your fork
 3. If you like the change and think the project could use it:
     * Be sure you have followed the code style for the project.
     * Make a pull request, and be sure to fill out the information in the template.
@@ -48,4 +48,4 @@ Before suggesting a feature, please read through the [Roadmap to MVP](https://gi
 After you submit your pull request, it will be reviewed within 10 business days and we will give you feedback on any needed changes. After feedback has been given we expect responses within two weeks. After two weeks we may close the pull request if it isn't showing any activity.
 
 # Code Style
-ESLint is used for checking JavaScript code style. It is also useful for avoiding some errors. Please use indentation of 2 spaces, and no semicolons. Please use ES2015.
+ESLint is used for checking JavaScript code style. It is also useful for avoiding some errors. Please use indentation of 2 spaces, and no semicolons. Please use ES2015 (ES6).

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ mix lint
 ```
 
 ## Contributing
-Coming soon!
+[Contributing Guidelines](CONTRIBUTING.md)
 
 ## Code of Conduct
 [The Contributor Covenant](CODE_OF_CONDUCT.md)


### PR DESCRIPTION
__Description of Change(s) Introduced:__ 
Tanya and I used [this](https://github.com/nayafia/contributing-template/blob/master/CONTRIBUTING-template.md) as a template.

I linked the CLA that Stride's lawyer prepared to our repo with [CLA assistant](https://cla-assistant.io/) (looks like it's used by some big open source projects like Eslint, so seems legit). Now when you make a pull request, you will be prompted to digitally sign the CLA with your Github account.

Here are the invdividual and corporate CLAs for reference:
https://gist.github.com/qlaire/cfcc3a2b9ab28f3c97716e4040afe578
https://gist.github.com/qlaire/c6b31ad2ba9489e75f6c810be466e7c6

There's a part of the guidelines that ask people to email us if they find a security vulnerability (so as not to make it public). Should we get a special security@remoteretro.org or security@stridenyc.com email address so we don't have to make our contact info public?

__Relevant github Issue:__ (if applicable)

- #208 
