### PR TITLE
Only display other users' vote counts after the voting phase - story# 277

### DIFF
--- a/test/components/vote_counter_test.js
+++ b/test/components/vote_counter_test.js
@@ -23,27 +23,65 @@ describe("VoteCounter", () => {
     currentUser: mockUser,
     retroChannel: {},
     buttonDisabled: false,
+    stage: "voting",
   }
 
-  it("renders an anchor tag that contains the vote count of the given idea", () => {
-    const voteForIdea = { idea_id: 23 }
-    const voteForOtherIdea = { idea_id: 45 }
-    const votes = [
-      voteForIdea,
-      voteForIdea,
-      voteForIdea,
-      voteForOtherIdea,
-    ]
+  context("during the voting stage", () => {
+    it("renders an anchor tag that contains the vote count of the given idea for the current user", () => {
+      const voteForIdea = { idea_id: 23, user_id: 55 }
+      const voteForIdeaForOtherUser = { idea_id: 23, user_id: 77 }
+      const voteForOtherIdea = { idea_id: 45, user_id: 1 }
+      const votes = [
+        voteForIdea,
+        voteForIdea,
+        voteForIdea,
+        voteForIdeaForOtherUser,
+        voteForOtherIdea,
+      ]
 
-    const voteCounter = mountWithConnectedSubcomponents(
-      <VoteCounter
-        {...defaultProps}
-        votes={votes}
-      />
-    )
-    const label = voteCounter.find("a")
+      const voteCounter = mountWithConnectedSubcomponents(
+        <VoteCounter
+          {...defaultProps}
+          votes={votes}
+        />
+      )
+      const label = voteCounter.find("a")
 
-    expect(label.text()).to.equal("3")
+      expect(label.text()).to.equal("3")
+    })
+  })
+
+  context("during the action-items stage", () => {
+    it("renders an anchor tag that contains the vote count of the given idea for all users", () => {
+      const defaultProps = {
+        idea,
+        votes: [],
+        currentUser: mockUser,
+        retroChannel: {},
+        buttonDisabled: false,
+        stage: "action-items",
+      }
+      const voteForIdea = { idea_id: 23, user_id: 55 }
+      const voteForIdeaForOtherUser = { idea_id: 23, user_id: 77 }
+      const voteForOtherIdea = { idea_id: 45, user_id: 1 }
+      const votes = [
+        voteForIdea,
+        voteForIdea,
+        voteForIdea,
+        voteForIdeaForOtherUser,
+        voteForOtherIdea,
+      ]
+
+      const voteCounter = mountWithConnectedSubcomponents(
+        <VoteCounter
+          {...defaultProps}
+          votes={votes}
+        />
+      )
+      const label = voteCounter.find("a")
+
+      expect(label.text()).to.equal("4")
+    })
   })
 
   context("when buttonDisabled is true", () => {

--- a/web/static/js/components/idea_controls.jsx
+++ b/web/static/js/components/idea_controls.jsx
@@ -36,6 +36,7 @@ export const IdeaControls = props => {
           votes={votes}
           buttonDisabled={stage !== "voting" || cannotVote}
           currentUser={currentUser}
+          stage={stage}
         />
       )
     }

--- a/web/static/js/components/stage_change_info_voting.jsx
+++ b/web/static/js/components/stage_change_info_voting.jsx
@@ -7,6 +7,7 @@ export default () => (
       <ul className="ui list">
         <li>You have <strong>5</strong> votes</li>
         <li>You can apply multiple votes to a given idea</li>
+        <li>Voting is blind. Totals will be revealed when the facilitator advances the retro.</li>
         <li>Once a vote has been cast, there's no taking it back, so vote carefully!</li>
       </ul>
     </div>

--- a/web/static/js/components/vote_counter.jsx
+++ b/web/static/js/components/vote_counter.jsx
@@ -18,12 +18,19 @@ class VoteCounter extends React.Component {
   }
 
   render() {
-    const { buttonDisabled, votes, idea } = this.props
+    const { buttonDisabled, votes, idea, stage } = this.props
     const counterClasses = classNames("ui labeled right floated button", {
       disabled: buttonDisabled,
     })
 
-    const voteCountForIdea = votes.filter(vote => vote.idea_id === idea.id).length
+    let voteCountForIdea
+    if (stage === "voting") {
+      voteCountForIdea = votes.filter(vote =>
+        vote.idea_id === idea.id && vote.user_id === this.props.currentUser.id
+      ).length
+    } else {
+      voteCountForIdea = votes.filter(vote => vote.idea_id === idea.id).length
+    }
 
     return (
       <div className={counterClasses}>
@@ -58,6 +65,7 @@ VoteCounter.propTypes = {
   votes: AppPropTypes.votes.isRequired,
   buttonDisabled: PropTypes.bool,
   currentUser: AppPropTypes.user.isRequired,
+  stage: AppPropTypes.stage.isRequired,
 }
 
 export default VoteCounter


### PR DESCRIPTION
This PR introduces the following change:
- During the voting stage, users should only see their own vote count.
- After the voting stage, users should see each idea's total vote count.

Testing:
- Front-end unit tests were updated to reflect these changes.

