### PR TITLE
Replace additional magic strings with constants for stage names - story# 230

### DIFF
--- a/test/actions/retro_actions_test.js
+++ b/test/actions/retro_actions_test.js
@@ -1,6 +1,9 @@
 import * as actionCreators from "../../web/static/js/actions/retro"
 
 import stageConfigs from "../../web/static/js/configs/stage_configs"
+import STAGES from "../../web/static/js/configs/stages"
+
+const { PRIME_DIRECTIVE } = STAGES
 
 describe("updateStage", () => {
   it("creates an action to update the retro's stage", () => {
@@ -16,7 +19,7 @@ describe("updateStage", () => {
 
 describe("setInitialState", () => {
   it("creates an action to set the retro's initial state", () => {
-    const initialState = { stage: "prime-directive", inserted_at: "2017-04-14T17:30:10" }
+    const initialState = { stage: PRIME_DIRECTIVE, inserted_at: "2017-04-14T17:30:10" }
 
     expect(actionCreators.setInitialState(initialState)).to.deep.equal({
       type: "SET_INITIAL_STATE",

--- a/test/components/category_column_test.js
+++ b/test/components/category_column_test.js
@@ -4,20 +4,19 @@ import sinon from "sinon"
 
 import { CategoryColumn } from "../../web/static/js/components/category_column"
 import Idea from "../../web/static/js/components/idea"
+import STAGES from "../../web/static/js/configs/stages"
+
+const { IDEA_GENERATION, VOTING, ACTION_ITEMS, CLOSED } = STAGES
 
 describe("CategoryColumn", () => {
   const mockUser = { given_name: "daniel" }
   const mockRetroChannel = { on: () => {}, push: () => {} }
-  const ideaGenerationStage = "idea-generation"
-  const actionItemStage = "action-items"
-  const actionItemDistributionStage = "closed"
-  const votingStage = "voting"
   const defaultProps = {
     currentUser: mockUser,
     retroChannel: mockRetroChannel,
     votes: [],
     ideas: [],
-    stage: ideaGenerationStage,
+    stage: IDEA_GENERATION,
     category: "confused",
   }
 
@@ -45,7 +44,7 @@ describe("CategoryColumn", () => {
           {...defaultProps}
           ideas={ideas}
           category="confused"
-          stage={ideaGenerationStage}
+          stage={IDEA_GENERATION}
         />
       )
 
@@ -58,7 +57,7 @@ describe("CategoryColumn", () => {
         <CategoryColumn
           {...defaultProps}
           ideas={ideas}
-          stage={votingStage}
+          stage={VOTING}
         />
       )
 
@@ -100,7 +99,7 @@ describe("CategoryColumn", () => {
             {...defaultProps}
             ideas={ideas}
             votes={votes}
-            stage={actionItemStage}
+            stage={ACTION_ITEMS}
           />
         )
 
@@ -109,7 +108,7 @@ describe("CategoryColumn", () => {
             {...defaultProps}
             ideas={ideas}
             votes={votes}
-            stage={actionItemDistributionStage}
+            stage={CLOSED}
           />
         )
 
@@ -153,7 +152,7 @@ describe("CategoryColumn", () => {
               {...defaultProps}
               ideas={ideas}
               votes={votes}
-              stage={actionItemStage}
+              stage={ACTION_ITEMS}
             />
           )
 
@@ -189,7 +188,7 @@ describe("CategoryColumn", () => {
             {...defaultProps}
             ideas={ideas}
             category="action-item"
-            stage={actionItemStage}
+            stage={ACTION_ITEMS}
           />
         )
 
@@ -234,11 +233,11 @@ describe("CategoryColumn", () => {
           {...defaultProps}
           votes={votes}
           ideas={ideas}
-          stage={votingStage}
+          stage={VOTING}
         />
       )
 
-      wrapper.setProps({ stage: actionItemStage })
+      wrapper.setProps({ stage: ACTION_ITEMS })
       let listItems = wrapper.find("li")
       expect(listItems.first().text()).to.match(/should be first at outset/)
 

--- a/test/components/idea_board_test.js
+++ b/test/components/idea_board_test.js
@@ -3,6 +3,9 @@ import { shallow } from "enzyme"
 
 import IdeaBoard from "../../web/static/js/components/idea_board"
 import CategoryColumn from "../../web/static/js/components/category_column"
+import STAGES from "../../web/static/js/configs/stages"
+
+const { IDEA_GENERATION, ACTION_ITEMS, CLOSED } = STAGES
 
 describe("IdeaBoard component", () => {
   let ideaBoard
@@ -13,12 +16,12 @@ describe("IdeaBoard component", () => {
     retroChannel: mockRetroChannel,
     users: [],
     ideas: [],
-    stage: "idea-generation",
+    stage: IDEA_GENERATION,
   }
 
   describe("when the stage is 'idea-generation'", () => {
     before(() => {
-      ideaBoard = shallow(<IdeaBoard {...defaultProps} stage="idea-generation" />)
+      ideaBoard = shallow(<IdeaBoard {...defaultProps} stage={IDEA_GENERATION} />)
     })
 
     it("renders columns for happy, sad, and confused ideas", () => {
@@ -28,7 +31,7 @@ describe("IdeaBoard component", () => {
 
   describe("when the stage is 'action-items'", () => {
     before(() => {
-      ideaBoard = shallow(<IdeaBoard {...defaultProps} stage="action-items" />)
+      ideaBoard = shallow(<IdeaBoard {...defaultProps} stage={ACTION_ITEMS} />)
     })
 
     it("renders a fourth column for displaying the action-items", () => {
@@ -38,7 +41,7 @@ describe("IdeaBoard component", () => {
 
   describe("when the stage is 'closed'", () => {
     before(() => {
-      ideaBoard = shallow(<IdeaBoard {...defaultProps} stage="closed" />)
+      ideaBoard = shallow(<IdeaBoard {...defaultProps} stage={CLOSED} />)
     })
 
     it("renders a fourth column for displaying the action-items", () => {

--- a/test/components/idea_controls_test.js
+++ b/test/components/idea_controls_test.js
@@ -4,13 +4,13 @@ import sinon from "sinon"
 
 import { IdeaControls } from "../../web/static/js/components/idea_controls"
 import VoteCounter from "../../web/static/js/components/vote_counter"
+import STAGES from "../../web/static/js/configs/stages"
+
+const { IDEA_GENERATION, VOTING, ACTION_ITEMS } = STAGES
 
 describe("<IdeaControls />", () => {
   const idea = { id: 666, category: "sad", body: "redundant tests", user_id: 1 }
   const mockUser = { id: 2, is_facilitator: true }
-  const ideaGenerationStage = "idea-generation"
-  const votingStage = "voting"
-  const actionItemsStage = "action-items"
 
   describe("on click of the removal icon", () => {
     it("pushes an `delete_idea` event to the retro channel, passing the given idea's id", () => {
@@ -21,7 +21,7 @@ describe("<IdeaControls />", () => {
           idea={idea}
           retroChannel={retroChannel}
           currentUser={mockUser}
-          stage={ideaGenerationStage}
+          stage={IDEA_GENERATION}
         />
       )
 
@@ -41,7 +41,7 @@ describe("<IdeaControls />", () => {
           idea={idea}
           retroChannel={retroChannel}
           currentUser={mockUser}
-          stage={ideaGenerationStage}
+          stage={IDEA_GENERATION}
         />
       )
 
@@ -61,7 +61,7 @@ describe("<IdeaControls />", () => {
           idea={idea}
           retroChannel={retroChannel}
           currentUser={mockUser}
-          stage={ideaGenerationStage}
+          stage={IDEA_GENERATION}
         />
       )
 
@@ -82,7 +82,7 @@ describe("<IdeaControls />", () => {
           idea={highlightedIdea}
           retroChannel={retroChannel}
           currentUser={mockUser}
-          stage={ideaGenerationStage}
+          stage={IDEA_GENERATION}
         />
       )
 
@@ -103,7 +103,7 @@ describe("<IdeaControls />", () => {
             idea={idea}
             retroChannel={retroChannel}
             currentUser={mockUser}
-            stage={ideaGenerationStage}
+            stage={IDEA_GENERATION}
           />
         )
 
@@ -125,7 +125,7 @@ describe("<IdeaControls />", () => {
               idea={idea}
               retroChannel={retroChannel}
               currentUser={currentUser}
-              stage={ideaGenerationStage}
+              stage={IDEA_GENERATION}
             />
           )
 
@@ -154,7 +154,7 @@ describe("<IdeaControls />", () => {
                 idea={freshIdea}
                 retroChannel={retroChannel}
                 currentUser={currentUser}
-                stage={ideaGenerationStage}
+                stage={IDEA_GENERATION}
               />
             )
 
@@ -174,7 +174,7 @@ describe("<IdeaControls />", () => {
                 idea={staleIdea}
                 retroChannel={retroChannel}
                 currentUser={currentUser}
-                stage={ideaGenerationStage}
+                stage={IDEA_GENERATION}
               />
             )
 
@@ -197,7 +197,7 @@ describe("<IdeaControls />", () => {
               idea={idea}
               retroChannel={retroChannel}
               currentUser={currentUser}
-              stage={votingStage}
+              stage={VOTING}
             />
           )
 
@@ -216,7 +216,7 @@ describe("<IdeaControls />", () => {
               idea={actionItemIdea}
               retroChannel={retroChannel}
               currentUser={currentUser}
-              stage={votingStage}
+              stage={VOTING}
             />
           )
 
@@ -235,7 +235,7 @@ describe("<IdeaControls />", () => {
             idea={idea}
             retroChannel={retroChannel}
             currentUser={currentUser}
-            stage={ideaGenerationStage}
+            stage={IDEA_GENERATION}
           />
          )
 
@@ -253,7 +253,7 @@ describe("<IdeaControls />", () => {
             idea={idea}
             retroChannel={retroChannel}
             currentUser={currentUser}
-            stage={actionItemsStage}
+            stage={ACTION_ITEMS}
           />
          )
 
@@ -274,7 +274,7 @@ describe("<IdeaControls />", () => {
             votes={votes}
             retroChannel={retroChannel}
             currentUser={currentUser}
-            stage={votingStage}
+            stage={VOTING}
           />
          )
 
@@ -292,7 +292,7 @@ describe("<IdeaControls />", () => {
             idea={idea}
             retroChannel={retroChannel}
             currentUser={currentUser}
-            stage={votingStage}
+            stage={VOTING}
           />
         )
 

--- a/test/components/idea_generation_lower_third_content_test.js
+++ b/test/components/idea_generation_lower_third_content_test.js
@@ -3,6 +3,9 @@ import { shallow } from "enzyme"
 
 import StageProgressionButton from "../../web/static/js/components/stage_progression_button"
 import IdeaGenerationLowerThirdContent from "../../web/static/js/components/idea_generation_lower_third_content" // eslint-disable-line line-length
+import STAGES from "../../web/static/js/configs/stages"
+
+const { IDEA_GENERATION, ACTION_ITEMS } = STAGES
 
 describe("<IdeaGenerationLowerThirdContent />", () => {
   const defaultProps = {
@@ -12,7 +15,7 @@ describe("<IdeaGenerationLowerThirdContent />", () => {
 
   context("when it's the `idea-generation` stage", () => {
     context("and there are no ideas", () => {
-      const noIdeasProps = { ...defaultProps, stage: "idea-generation", ideas: [] }
+      const noIdeasProps = { ...defaultProps, stage: IDEA_GENERATION, ideas: [] }
 
       it("renders a disabled <StageProgressionButton>", () => {
         const lowerThird = shallow(
@@ -26,7 +29,7 @@ describe("<IdeaGenerationLowerThirdContent />", () => {
     context("and there are ideas", () => {
       const propsWithIdeas = {
         ...defaultProps,
-        stage: "idea-generation",
+        stage: IDEA_GENERATION,
         ideas: [{ category: "happy" }],
       }
 
@@ -47,7 +50,7 @@ describe("<IdeaGenerationLowerThirdContent />", () => {
         const lowerThird = shallow(
           <IdeaGenerationLowerThirdContent
             {...defaultProps}
-            stage="action-items"
+            stage={ACTION_ITEMS}
             ideas={[]}
           />
         )
@@ -61,7 +64,7 @@ describe("<IdeaGenerationLowerThirdContent />", () => {
         const lowerThird = shallow(
           <IdeaGenerationLowerThirdContent
             {...defaultProps}
-            stage="action-items"
+            stage={ACTION_ITEMS}
             ideas={[{ category: "action-item" }]}
           />
         )

--- a/test/components/idea_submission_form_test.js
+++ b/test/components/idea_submission_form_test.js
@@ -2,6 +2,9 @@ import React from "react"
 import sinon from "sinon"
 
 import { IdeaSubmissionForm } from "../../web/static/js/components/idea_submission_form"
+import STAGES from "../../web/static/js/configs/stages"
+
+const { IDEA_GENERATION, VOTING } = STAGES
 
 describe("IdeaSubmissionForm component", () => {
   let wrapper
@@ -244,7 +247,7 @@ describe("IdeaSubmissionForm component", () => {
             <IdeaSubmissionForm
               currentUser={stubUser}
               retroChannel={mockRetroChannel}
-              stage="idea-generation"
+              stage={IDEA_GENERATION}
               showActionItem
             />
           )
@@ -260,7 +263,7 @@ describe("IdeaSubmissionForm component", () => {
             <IdeaSubmissionForm
               currentUser={stubUser}
               retroChannel={mockRetroChannel}
-              stage="voting"
+              stage={VOTING}
               showActionItem
             />
           )

--- a/test/components/idea_test.js
+++ b/test/components/idea_test.js
@@ -4,6 +4,9 @@ import { shallow } from "enzyme"
 import Idea from "../../web/static/js/components/idea"
 import IdeaControls from "../../web/static/js/components/idea_controls"
 import IdeaEditForm from "../../web/static/js/components/idea_edit_form"
+import STAGES from "../../web/static/js/configs/stages"
+
+const { IDEA_GENERATION, CLOSED } = STAGES
 
 describe("Idea component", () => {
   const idea = {
@@ -16,8 +19,6 @@ describe("Idea component", () => {
   }
   const mockRetroChannel = { on: () => {}, push: () => {} }
   const mockUser = {}
-  const ideaGenerationStage = "idea-generation"
-  const closedStage = "closed"
 
   context("when the user is a facilitator", () => {
     const facilitatorUser = { is_facilitator: true }
@@ -26,7 +27,7 @@ describe("Idea component", () => {
         idea={idea}
         currentUser={facilitatorUser}
         retroChannel={mockRetroChannel}
-        stage={ideaGenerationStage}
+        stage={IDEA_GENERATION}
       />
     )
 
@@ -44,7 +45,7 @@ describe("Idea component", () => {
           idea={idea}
           currentUser={facilitatorUser}
           retroChannel={mockRetroChannel}
-          stage={closedStage}
+          stage={CLOSED}
         />
       )
 
@@ -62,7 +63,7 @@ describe("Idea component", () => {
         idea={ideaInDefaultState}
         currentUser={mockUser}
         retroChannel={mockRetroChannel}
-        stage={ideaGenerationStage}
+        stage={IDEA_GENERATION}
       />
     )
 
@@ -83,7 +84,7 @@ describe("Idea component", () => {
         idea={ideaInEditState}
         currentUser={mockUser}
         retroChannel={mockRetroChannel}
-        stage={ideaGenerationStage}
+        stage={IDEA_GENERATION}
       />
     )
 
@@ -100,7 +101,7 @@ describe("Idea component", () => {
           idea={ideaInEditState}
           currentUser={facilitatorUser}
           retroChannel={mockRetroChannel}
-          stage={ideaGenerationStage}
+          stage={IDEA_GENERATION}
         />
       )
 
@@ -120,7 +121,7 @@ describe("Idea component", () => {
           idea={ideaInEditState}
           currentUser={nonFacilitatorUser}
           retroChannel={mockRetroChannel}
-          stage={ideaGenerationStage}
+          stage={IDEA_GENERATION}
         />
       )
 
@@ -138,7 +139,7 @@ describe("Idea component", () => {
             idea={{ ...ideaInEditState, liveEditText: "editing bigtime" }}
             currentUser={nonFacilitatorUser}
             retroChannel={mockRetroChannel}
-            stage={ideaGenerationStage}
+            stage={IDEA_GENERATION}
           />
         )
         it("displays the `liveEditText` value rather than the body value", () => {
@@ -163,7 +164,7 @@ describe("Idea component", () => {
         idea={editedIdea}
         currentUser={mockUser}
         retroChannel={mockRetroChannel}
-        stage={ideaGenerationStage}
+        stage={IDEA_GENERATION}
       />
     )
 

--- a/test/components/lower_third_animation_wrapper_test.js
+++ b/test/components/lower_third_animation_wrapper_test.js
@@ -1,6 +1,9 @@
 import React from "react"
 
 import LowerThirdAnimationWrapper from "../../web/static/js/components/lower_third_animation_wrapper"
+import STAGES from "../../web/static/js/configs/stages"
+
+const { IDEA_GENERATION } = STAGES
 
 describe("LowerThirdAnimationWrapper component", () => {
   let lowerThird
@@ -8,7 +11,7 @@ describe("LowerThirdAnimationWrapper component", () => {
   context("when displayContent is true", () => {
     beforeEach(() => {
       lowerThird = mountWithConnectedSubcomponents(
-        <LowerThirdAnimationWrapper displayContents stage="idea-generation">
+        <LowerThirdAnimationWrapper displayContents stage={IDEA_GENERATION}>
           <p>Hello</p>
         </LowerThirdAnimationWrapper>
       )
@@ -22,7 +25,7 @@ describe("LowerThirdAnimationWrapper component", () => {
   context("when displayContent is false", () => {
     beforeEach(() => {
       lowerThird = mountWithConnectedSubcomponents(
-        <LowerThirdAnimationWrapper displayContents={false} stage="idea-generation">
+        <LowerThirdAnimationWrapper displayContents={false} stage={IDEA_GENERATION}>
           <p>Hello</p>
         </LowerThirdAnimationWrapper>
       )

--- a/test/components/lower_third_test.js
+++ b/test/components/lower_third_test.js
@@ -5,17 +5,19 @@ import { spy } from "sinon"
 import LowerThird from "../../web/static/js/components/lower_third"
 import IdeaGenerationLowerThirdContent from "../../web/static/js/components/idea_generation_lower_third_content" // eslint-disable-line line-length
 import VotingLowerThirdContent from "../../web/static/js/components/voting_lower_third_content"
+import STAGES from "../../web/static/js/configs/stages"
+
+const { IDEA_GENERATION, VOTING, CLOSED } = STAGES
 
 describe("LowerThird component", () => {
   const mockRetroChannel = { push: spy(), on: () => {} }
   const stubUser = { given_name: "Mugatu" }
-  const votingStage = "voting"
   const defaultProps = {
     currentUser: stubUser,
     retroChannel: mockRetroChannel,
     users: [],
     ideas: [],
-    stage: "idea-generation",
+    stage: IDEA_GENERATION,
   }
 
   context("when the stage is `closed`", () => {
@@ -23,7 +25,7 @@ describe("LowerThird component", () => {
       const lowerThird = shallow(
         <LowerThird
           {...defaultProps}
-          stage="closed"
+          stage={CLOSED}
         />
       )
 
@@ -36,7 +38,7 @@ describe("LowerThird component", () => {
       const lowerThird = shallow(
         <LowerThird
           {...defaultProps}
-          stage="idea-generation"
+          stage={IDEA_GENERATION}
         />
       )
 
@@ -49,7 +51,7 @@ describe("LowerThird component", () => {
       const lowerThird = shallow(
         <LowerThird
           {...defaultProps}
-          stage={votingStage}
+          stage={VOTING}
         />
       )
 

--- a/test/components/remote_retro_test.js
+++ b/test/components/remote_retro_test.js
@@ -2,6 +2,9 @@ import React from "react"
 import { spy } from "sinon"
 
 import { RemoteRetro } from "../../web/static/js/components/remote_retro"
+import STAGES from "../../web/static/js/configs/stages"
+
+const { IDEA_GENERATION, CLOSED } = STAGES
 
 describe("RemoteRetro component", () => {
   const mockRetroChannel = {}
@@ -11,7 +14,7 @@ describe("RemoteRetro component", () => {
     retroChannel: mockRetroChannel,
     users: [],
     ideas: [],
-    stage: "idea-generation",
+    stage: IDEA_GENERATION,
     userToken: "",
   }
 
@@ -20,10 +23,10 @@ describe("RemoteRetro component", () => {
       const hotjarSpy = spy(global, "hj")
 
       mountWithConnectedSubcomponents(
-        <RemoteRetro {...defaultProps} stage="closed" />
+        <RemoteRetro {...defaultProps} stage={CLOSED} />
       )
 
-      expect(hotjarSpy.calledWith("trigger", "closed")).to.eql(true)
+      expect(hotjarSpy.calledWith("trigger", CLOSED)).to.eql(true)
       hotjarSpy.restore()
     })
   })

--- a/test/components/room_test.js
+++ b/test/components/room_test.js
@@ -4,6 +4,9 @@ import { shallow } from "enzyme"
 import Room from "../../web/static/js/components/room"
 import PrimeDirectiveStage from "../../web/static/js/components/prime_directive_stage"
 import IdeaGenerationStage from "../../web/static/js/components/idea_generation_stage"
+import STAGES from "../../web/static/js/configs/stages"
+
+const { PRIME_DIRECTIVE, IDEA_GENERATION } = STAGES
 
 describe("Room", () => {
   let room
@@ -15,7 +18,7 @@ describe("Room", () => {
   describe("when the stage is prime-directive", () => {
     room = shallow(
       <Room
-        stage="prime-directive"
+        stage={PRIME_DIRECTIVE}
         users={users}
       />
     )
@@ -30,7 +33,7 @@ describe("Room", () => {
   describe("when the stage is not prime-directive", () => {
     const ideaRoom = shallow(
       <Room
-        stage="idea-generation"
+        stage={IDEA_GENERATION}
         users={users}
         ideas={[]}
         retroChannel={{}}

--- a/test/components/user_list_item_test.js
+++ b/test/components/user_list_item_test.js
@@ -2,6 +2,9 @@ import React from "react"
 import { shallow, mount } from "enzyme"
 
 import { UserListItem } from "../../web/static/js/components/user_list_item"
+import STAGES from "../../web/static/js/configs/stages"
+
+const { IDEA_GENERATION, VOTING } = STAGES
 
 const defaultUserAttrs = {
   given_name: "dylan",
@@ -13,7 +16,7 @@ const defaultUserAttrs = {
 
 const defaultProps = {
   votes: [],
-  stage: "idea-generation",
+  stage: IDEA_GENERATION,
   user: defaultUserAttrs,
 }
 
@@ -52,7 +55,7 @@ describe("UserListItem", () => {
           <UserListItem
             {...defaultProps}
             user={user}
-            stage="idea-generation"
+            stage={IDEA_GENERATION}
           />
         )
 
@@ -67,7 +70,7 @@ describe("UserListItem", () => {
         const wrapper = shallow(
           <UserListItem
             {...defaultProps}
-            stage="idea-generation"
+            stage={IDEA_GENERATION}
             user={user}
           />
         )
@@ -85,12 +88,12 @@ describe("UserListItem", () => {
 
   context("when the stage is voting", () => {
     it("does not render the animated ellipsis wrapper", () => {
-      const wrapper = shallow(<UserListItem {...defaultProps} stage="voting" />)
+      const wrapper = shallow(<UserListItem {...defaultProps} stage={VOTING} />)
       expect(wrapper.text()).to.not.match(/animatedellipsis/i)
     })
 
     it("renders a voting status span", () => {
-      const wrapper = shallow(<UserListItem {...defaultProps} stage="voting" />)
+      const wrapper = shallow(<UserListItem {...defaultProps} stage={VOTING} />)
       expect(wrapper.html()).to.contain("allVotesIn")
     })
 
@@ -103,7 +106,7 @@ describe("UserListItem", () => {
         const wrapper = shallow(
           <UserListItem
             user={userWithFiveVotes}
-            stage="voting"
+            stage={VOTING}
             votes={votes}
           />
         )
@@ -121,7 +124,7 @@ describe("UserListItem", () => {
         const wrapper = shallow(
           <UserListItem
             user={userWithFourVotes}
-            stage="voting"
+            stage={VOTING}
             votes={votes}
           />
         )

--- a/test/components/vote_counter_test.js
+++ b/test/components/vote_counter_test.js
@@ -3,6 +3,9 @@ import { shallow } from "enzyme"
 import { spy } from "sinon"
 
 import VoteCounter from "../../web/static/js/components/vote_counter"
+import STAGES from "../../web/static/js/configs/stages"
+
+const { ACTION_ITEMS, VOTING } = STAGES
 
 describe("VoteCounter", () => {
   const idea = {
@@ -23,7 +26,7 @@ describe("VoteCounter", () => {
     currentUser: mockUser,
     retroChannel: {},
     buttonDisabled: false,
-    stage: "voting",
+    stage: VOTING,
   }
 
   context("during the voting stage", () => {
@@ -59,7 +62,7 @@ describe("VoteCounter", () => {
         currentUser: mockUser,
         retroChannel: {},
         buttonDisabled: false,
-        stage: "action-items",
+        stage: ACTION_ITEMS,
       }
       const voteForIdea = { idea_id: 23, user_id: 55 }
       const voteForIdeaForOtherUser = { idea_id: 23, user_id: 77 }

--- a/test/services/retro_channel_test.js
+++ b/test/services/retro_channel_test.js
@@ -3,6 +3,9 @@ import { spy, useFakeTimers } from "sinon"
 import { createStore } from "redux"
 
 import RetroChannel from "../../web/static/js/services/retro_channel"
+import STAGES from "../../web/static/js/configs/stages"
+
+const { CLOSED } = STAGES
 
 describe("RetroChannel", () => {
   describe(".configure", () => {
@@ -21,7 +24,7 @@ describe("RetroChannel", () => {
 
     describe("the returned Phoenix channel", () => {
       it("is closed", () => {
-        expect(result.state).to.equal("closed")
+        expect(result.state).to.equal(CLOSED)
       })
 
       it("has a topic attribute identifying the retro with the supplied UUID", () => {

--- a/test/support/js/test_helper.js
+++ b/test/support/js/test_helper.js
@@ -2,6 +2,9 @@ import { expect } from "chai"
 import { mount } from "enzyme"
 import PropTypes from "prop-types"
 import noop from "lodash/noop"
+import STAGES from "../../../web/static/js/configs/stages"
+
+const { IDEA_GENERATION } = STAGES
 
 global.hj = noop
 global.expect = expect
@@ -10,7 +13,7 @@ global.mountWithConnectedSubcomponents = (component, options) => {
   const store = {
     subscribe: () => {},
     dispatch: () => {},
-    getState: () => ({ votes: [], stage: "idea-generation" }),
+    getState: () => ({ votes: [], stage: IDEA_GENERATION }),
   }
 
   const defaultOptions = {

--- a/web/static/js/components/category_column.jsx
+++ b/web/static/js/components/category_column.jsx
@@ -6,17 +6,20 @@ import ShadowedScrollContainer from "./shadowed_scroll_container"
 import Idea from "./idea"
 import * as AppPropTypes from "../prop_types"
 import styles from "./css_modules/category_column.css"
+import STAGES from "../configs/stages"
+
+const { VOTING, ACTION_ITEMS, CLOSED } = STAGES
 
 export class CategoryColumn extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      animateSort: props.stage === "action-items" || props.stage === "closed",
+      animateSort: props.stage === ACTION_ITEMS || props.stage === CLOSED,
     }
   }
 
   componentWillReceiveProps(nextProps) {
-    if (this.props.stage === "voting" && nextProps.stage === "action-items") {
+    if (this.props.stage === VOTING && nextProps.stage === ACTION_ITEMS) {
       const timeout = setTimeout(() => {
         this.setState({ animateSort: true })
         clearTimeout(timeout)

--- a/web/static/js/components/idea.jsx
+++ b/web/static/js/components/idea.jsx
@@ -5,6 +5,9 @@ import IdeaControls from "./idea_controls"
 import IdeaEditForm from "./idea_edit_form"
 import * as AppPropTypes from "../prop_types"
 import styles from "./css_modules/idea.css"
+import STAGES from "../configs/stages"
+
+const { CLOSED } = STAGES
 
 const Idea = props => {
   const { idea, currentUser, retroChannel, stage } = props
@@ -34,7 +37,7 @@ const Idea = props => {
   )
 
   const renderIdeaControls = () => {
-    if (stage !== "closed") {
+    if (stage !== CLOSED) {
       return ideaControls
     }
     return null

--- a/web/static/js/components/idea_board.jsx
+++ b/web/static/js/components/idea_board.jsx
@@ -4,11 +4,14 @@ import CategoryColumn from "./category_column"
 
 import * as AppPropTypes from "../prop_types"
 import styles from "./css_modules/idea_board.css"
+import STAGES from "../configs/stages"
+
+const { ACTION_ITEMS, CLOSED } = STAGES
 
 const IdeaBoard = props => {
   const { stage } = props
   const categories = ["happy", "sad", "confused"]
-  const showActionItem = ["action-items", "closed"].includes(stage)
+  const showActionItem = [ACTION_ITEMS, CLOSED].includes(stage)
   if (showActionItem) { categories.push("action-item") }
 
   const categoryColumns = categories.map(category => (

--- a/web/static/js/components/idea_controls.jsx
+++ b/web/static/js/components/idea_controls.jsx
@@ -6,6 +6,9 @@ import * as AppPropTypes from "../prop_types"
 import styles from "./css_modules/idea_controls.css"
 import VoteCounter from "./vote_counter"
 import { voteMax } from "../configs/retro_configs"
+import STAGES from "../configs/stages"
+
+const { IDEA_GENERATION, VOTING } = STAGES
 
 const timeElapsedLessThanFiveSec = ideaCreationTimestamp => {
   const millisecondsSinceIdeaCreation = new Date(ideaCreationTimestamp)
@@ -28,13 +31,13 @@ export const IdeaControls = props => {
   const cannotVote = voteCount >= voteMax
 
   function renderIcons() {
-    if (stage !== "idea-generation" && category !== "action-item") {
+    if (stage !== IDEA_GENERATION && category !== "action-item") {
       return (
         <VoteCounter
           retroChannel={retroChannel}
           idea={idea}
           votes={votes}
-          buttonDisabled={stage !== "voting" || cannotVote}
+          buttonDisabled={stage !== VOTING || cannotVote}
           currentUser={currentUser}
           stage={stage}
         />

--- a/web/static/js/components/idea_generation_lower_third_content.jsx
+++ b/web/static/js/components/idea_generation_lower_third_content.jsx
@@ -5,16 +5,19 @@ import StageProgressionButton from "./stage_progression_button"
 import stageConfigs from "../configs/stage_configs"
 
 import * as AppPropTypes from "../prop_types"
+import STAGES from "../configs/stages"
+
+const { IDEA_GENERATION, ACTION_ITEMS, CLOSED } = STAGES
 
 const IdeaGenerationLowerThirdContent = props => {
   const { stage, ideas } = props
 
   const stageConfig = stageConfigs[stage]
-  const showActionItem = ["action-items", "closed"].includes(stage)
+  const showActionItem = [ACTION_ITEMS, CLOSED].includes(stage)
 
   function progressionDisabled() {
-    const noIdeasCreated = stage === "idea-generation" && !ideas.length
-    const noActionItemsCreated = stage === "action-items" && !ideas.some(idea => idea.category === "action-item")
+    const noIdeasCreated = stage === IDEA_GENERATION && !ideas.length
+    const noActionItemsCreated = stage === ACTION_ITEMS && !ideas.some(idea => idea.category === "action-item")
     return noIdeasCreated || noActionItemsCreated
   }
 

--- a/web/static/js/components/idea_submission_form.jsx
+++ b/web/static/js/components/idea_submission_form.jsx
@@ -6,6 +6,9 @@ import * as AppPropTypes from "../prop_types"
 import { USER_TYPING_ANIMATION_DURATION } from "../services/user_activity"
 
 import styles from "./css_modules/idea_submission_form.css"
+import STAGES from "../configs/stages"
+
+const { IDEA_GENERATION } = STAGES
 
 const PLACEHOLDER_TEXTS = {
   happy: "we have a linter!",
@@ -72,7 +75,7 @@ export class IdeaSubmissionForm extends Component {
     ]
     let pointingLabel = null
 
-    if (!this.state.ideaEntryStarted && this.props.stage === "idea-generation") {
+    if (!this.state.ideaEntryStarted && this.props.stage === IDEA_GENERATION) {
       pointingLabel = (
         <div className={`${styles.pointingLabel} floating ui pointing below teal label`}>
           Submit an idea!
@@ -128,7 +131,7 @@ IdeaSubmissionForm.propTypes = {
 
 IdeaSubmissionForm.defaultProps = {
   alert: null,
-  stage: "idea-generation",
+  stage: IDEA_GENERATION,
 }
 
 const mapStateToProps = ({ alert }) => ({ alert })

--- a/web/static/js/components/lower_third.jsx
+++ b/web/static/js/components/lower_third.jsx
@@ -6,6 +6,9 @@ import LowerThirdAnimationWrapper from "./lower_third_animation_wrapper"
 import stageConfigs from "../configs/stage_configs"
 
 import * as AppPropTypes from "../prop_types"
+import STAGES from "../configs/stages"
+
+const { VOTING, CLOSED } = STAGES
 
 const LowerThird = props => {
   const { stage } = props
@@ -13,7 +16,7 @@ const LowerThird = props => {
   const stageConfig = stageConfigs[stage]
 
   function stageSpecificContent() {
-    if (stage === "voting") {
+    if (stage === VOTING) {
       return <VotingLowerThirdContent {...props} config={stageConfig} />
     }
 
@@ -21,7 +24,7 @@ const LowerThird = props => {
   }
 
   return (
-    <LowerThirdAnimationWrapper displayContents={stage !== "closed"} stage={stage}>
+    <LowerThirdAnimationWrapper displayContents={stage !== CLOSED} stage={stage}>
       {stageSpecificContent()}
     </LowerThirdAnimationWrapper>
   )

--- a/web/static/js/components/user_list_item.jsx
+++ b/web/static/js/components/user_list_item.jsx
@@ -4,6 +4,9 @@ import { voteMax } from "../configs/retro_configs"
 import * as AppPropTypes from "../prop_types"
 import styles from "./css_modules/user_list_item.css"
 import AnimatedEllipsis from "./animated_ellipsis"
+import STAGES from "../configs/stages"
+
+const { VOTING } = STAGES
 
 export const UserListItem = ({ user, votes, stage }) => {
   let givenName = user.given_name
@@ -17,8 +20,8 @@ export const UserListItem = ({ user, votes, stage }) => {
     <li className={`item ${styles.wrapper}`}>
       <img className={styles.picture} src={imgSrc} alt={givenName} />
       <p data-hj-masked>{givenName}</p>
-      { stage !== "voting" && <AnimatedEllipsis animated={user.is_typing} /> }
-      { stage === "voting" &&
+      { stage !== VOTING && <AnimatedEllipsis animated={user.is_typing} /> }
+      { stage === VOTING &&
         <span className={`${styles.allVotesIn} ${allVotesIn ? "opaque" : ""}`}>ALL VOTES IN</span>
       }
     </li>

--- a/web/static/js/components/vote_counter.jsx
+++ b/web/static/js/components/vote_counter.jsx
@@ -5,6 +5,9 @@ import classNames from "classnames"
 
 import * as AppPropTypes from "../prop_types"
 import styles from "./css_modules/vote_counter.css"
+import STAGES from "../configs/stages"
+
+const { VOTING } = STAGES
 
 class VoteCounter extends React.Component {
   constructor(props) {
@@ -24,7 +27,7 @@ class VoteCounter extends React.Component {
     })
 
     let voteCountForIdea
-    if (stage === "voting") {
+    if (stage === VOTING) {
       voteCountForIdea = votes.filter(vote =>
         vote.idea_id === idea.id && vote.user_id === this.props.currentUser.id
       ).length


### PR DESCRIPTION
Replace all instances of magic strings with constants on the front-end for stage names.

No new dependencies.
No new tests.

story: https://github.com/stride-nyc/remote_retro/issues/230


