### PR TITLE
Update mocha watcher configuration to compile jsx files on edit

### DIFF
--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,5 +1,6 @@
 test/**/*_test.js
 --color
+--compilers jsx:babel-register
 --require mock-css-modules
 --require babel-register
 --require=env-test


### PR DESCRIPTION
The mocha test watch was previous ignoring any changes to the jsx files under test. This corrects the situation and makes TDD with the mocha watcher a happy time.