### PR TITLE
Change number of max votes per user from 5 to 3

### DIFF
--- a/test/components/user_list_item_test.js
+++ b/test/components/user_list_item_test.js
@@ -97,10 +97,10 @@ describe("UserListItem", () => {
       expect(wrapper.html()).to.contain("allVotesIn")
     })
 
-    context("and the given user has more than 4 votes", () => {
+    context("and the given user has more than 2 votes", () => {
       const userWithFiveVotes = { ...defaultUserAttrs, id: 999 }
       const voteForUser = { user_id: 999 }
-      const votes = [voteForUser, voteForUser, voteForUser, voteForUser, voteForUser]
+      const votes = [voteForUser, voteForUser, voteForUser]
 
       it("renders an opaque span indicating that the user is done voting", () => {
         const wrapper = shallow(
@@ -115,10 +115,10 @@ describe("UserListItem", () => {
       })
     })
 
-    context("and the given user has less than 5 votes", () => {
+    context("and the given user has less than 3 votes", () => {
       const userWithFourVotes = { ...defaultUserAttrs, id: 999 }
       const voteForUser = { user_id: 999 }
-      const votes = [voteForUser, voteForUser, voteForUser, voteForUser]
+      const votes = [voteForUser, voteForUser]
 
       it("does not apply opaqueness to text indicating that the user is done voting", () => {
         const wrapper = shallow(

--- a/test/components/votes_left_test.js
+++ b/test/components/votes_left_test.js
@@ -8,17 +8,16 @@ describe("VotesLeft component", () => {
   const voteForUser = { user_id: 5 }
   const voteForOtherUser = { user_id: 7 }
 
-  it("renders 5 Votes Left for a user that hasn't voted yet", () => {
+  it("renders 3 Votes Left for a user that hasn't voted yet", () => {
     const lowerThird = shallow(
       <VotesLeft currentUser={user} votes={[]} />
     )
 
-    expect(lowerThird.text()).to.match(/5.*Votes Left/)
+    expect(lowerThird.text()).to.match(/3.*Votes Left/)
   })
 
-  it("renders the Votes Left (5 minus their votes) for the currentUser", () => {
+  it("renders the Votes Left (3 minus their votes) for the currentUser", () => {
     const votes = [
-      voteForUser,
       voteForUser,
       voteForOtherUser,
     ]
@@ -27,13 +26,11 @@ describe("VotesLeft component", () => {
       <VotesLeft currentUser={user} votes={votes} />
     )
 
-    expect(lowerThird.text()).to.match(/3.*Votes Left/)
+    expect(lowerThird.text()).to.match(/2.*Votes Left/)
   })
 
   it("renders singular Vote if the user has one vote left", () => {
     const votes = [
-      voteForUser,
-      voteForUser,
       voteForUser,
       voteForUser,
     ]

--- a/web/channels/retro_channel.ex
+++ b/web/channels/retro_channel.ex
@@ -84,7 +84,7 @@ defmodule RemoteRetro.RetroChannel do
 
     user_vote_count = Repo.aggregate(query, :count, :id)
 
-    if user_vote_count < 5 do
+    if user_vote_count < 3 do
       broadcast! socket, "vote_submitted", %{"idea_id" => idea_id, "user_id" => user_id}
 
       %Vote{

--- a/web/static/js/components/stage_change_info_voting.jsx
+++ b/web/static/js/components/stage_change_info_voting.jsx
@@ -5,7 +5,7 @@ export default () => (
     The skinny on voting:
     <div className="ui basic segment">
       <ul className="ui list">
-        <li>You have <strong>5</strong> votes</li>
+        <li>You have <strong>3</strong> votes</li>
         <li>You can apply multiple votes to a given idea</li>
         <li>Voting is blind. Totals will be revealed when the facilitator advances the retro.</li>
         <li>Once a vote has been cast, there's no taking it back, so vote carefully!</li>

--- a/web/static/js/configs/retro_configs.js
+++ b/web/static/js/configs/retro_configs.js
@@ -1,4 +1,4 @@
-export const voteMax = 5
+export const voteMax = 3
 
 export default {
   voteMax,


### PR DESCRIPTION
This PR changes the max votes per user from 5 to 3.

No new dependencies.

Tests have been updated accordingly.

Relevant github Issue:
- [308](https://github.com/stride-nyc/remote_retro/issues/308)
