### PR TITLE
Refactor categories from the IdeaBoard

### DIFF
--- a/test/components/idea_board_test.js
+++ b/test/components/idea_board_test.js
@@ -4,6 +4,7 @@ import { shallow } from "enzyme"
 import IdeaBoard from "../../web/static/js/components/idea_board"
 import CategoryColumn from "../../web/static/js/components/category_column"
 import STAGES from "../../web/static/js/configs/stages"
+import { CATEGORIES } from "../../web/static/js/configs/retro_configs"
 
 const { IDEA_GENERATION, ACTION_ITEMS, CLOSED } = STAGES
 
@@ -17,6 +18,7 @@ describe("IdeaBoard component", () => {
     users: [],
     ideas: [],
     stage: IDEA_GENERATION,
+    categories: CATEGORIES,
   }
 
   describe("when the stage is 'idea-generation'", () => {

--- a/web/static/js/components/idea_board.jsx
+++ b/web/static/js/components/idea_board.jsx
@@ -9,12 +9,12 @@ import STAGES from "../configs/stages"
 const { ACTION_ITEMS, CLOSED } = STAGES
 
 const IdeaBoard = props => {
-  const { stage } = props
-  const categories = ["happy", "sad", "confused"]
+  const { stage, categories } = props
   const showActionItem = [ACTION_ITEMS, CLOSED].includes(stage)
-  if (showActionItem) { categories.push("action-item") }
+  const renderableColumnCategories = [...categories]
+  if (showActionItem) { renderableColumnCategories.push("action-item") }
 
-  const categoryColumns = categories.map(category => (
+  const categoryColumns = renderableColumnCategories.map(category => (
     <CategoryColumn {...props} category={category} key={category} />
   ))
 
@@ -35,6 +35,7 @@ IdeaBoard.propTypes = {
   retroChannel: AppPropTypes.retroChannel.isRequired,
   stage: AppPropTypes.stage.isRequired,
   users: AppPropTypes.users.isRequired,
+  categories: AppPropTypes.categories.isRequired,
 }
 
 export default IdeaBoard

--- a/web/static/js/components/remote_retro.jsx
+++ b/web/static/js/components/remote_retro.jsx
@@ -6,6 +6,7 @@ import * as AppPropTypes from "../prop_types"
 import Room from "./room"
 import Alert from "./alert"
 import DoorChime from "./door_chime"
+import { CATEGORIES } from "../configs/retro_configs"
 
 export class RemoteRetro extends Component {
   // Trigger analytics events on page load and stage changes
@@ -20,7 +21,7 @@ export class RemoteRetro extends Component {
 
   render() {
     const { users, ideas, userToken, retroChannel, stage, alert } = this.props
-
+    const categories = CATEGORIES
     const currentUser = users.find(user => user.token === userToken)
 
     return (
@@ -31,6 +32,7 @@ export class RemoteRetro extends Component {
           ideas={ideas}
           stage={stage}
           retroChannel={retroChannel}
+          categories={categories}
         />
         <Alert config={alert} />
         <DoorChime users={users} />

--- a/web/static/js/configs/retro_configs.js
+++ b/web/static/js/configs/retro_configs.js
@@ -1,4 +1,5 @@
 export const voteMax = 3
+export const CATEGORIES = ["happy", "sad", "confused"]
 
 export default {
   voteMax,

--- a/web/static/js/prop_types.js
+++ b/web/static/js/prop_types.js
@@ -40,6 +40,8 @@ export const stage = PropTypes.oneOf([
   CLOSED,
 ])
 
+export const categories = PropTypes.arrayOf(PropTypes.string)
+
 export const votes = PropTypes.arrayOf(PropTypes.object)
 
 export const ideas = PropTypes.arrayOf(idea)


### PR DESCRIPTION
This PR replaces hardcoded categories in IdeaBoard with categories passed in as props.
The categories have been placed into a separate constants file.

No new dependencies.
Tests have been updated accordingly.

Relevant github Issue:
- [309](https://github.com/stride-nyc/remote_retro/issues/309)
