### PR TITLE
Allow facilitators to change idea category- story# 325

### DIFF
--- a/test/channels/retro_channel_test.exs
+++ b/test/channels/retro_channel_test.exs
@@ -136,20 +136,21 @@ defmodule RemoteRetro.RetroChannelTest do
     @tag idea: %Idea{category: "sad", body: "JavaScript"}
     test "results in the broadcast of the edited idea to all connected clients", %{socket: socket, idea: idea} do
       idea_id = idea.id
-      push(socket, "idea_edited", %{id: idea_id, body: "hell's bells"})
+      push(socket, "idea_edited", %{id: idea_id, body: "hell's bells", category: "happy"})
 
-      assert_broadcast("idea_edited", %{body: "hell's bells", id: ^idea_id})
+      assert_broadcast("idea_edited", %{body: "hell's bells", category: "happy", id: ^idea_id})
     end
 
 
     @tag idea: %Idea{category: "sad", body: "doggone keeper"}
     test "results in the idea being updated in the database", %{socket: socket, idea: idea} do
       idea_id = idea.id
-      push(socket, "idea_edited", %{id: idea_id, body: "hell's bells"})
+      push(socket, "idea_edited", %{id: idea_id, body: "hell's bells", category: "confused"})
 
       :timer.sleep(50)
       idea = Repo.get!(Idea, idea_id)
       assert idea.body == "hell's bells"
+      assert idea.category == "confused"
     end
   end
 

--- a/test/components/category_column_test.js
+++ b/test/components/category_column_test.js
@@ -5,6 +5,7 @@ import sinon from "sinon"
 import { CategoryColumn } from "../../web/static/js/components/category_column"
 import Idea from "../../web/static/js/components/idea"
 import STAGES from "../../web/static/js/configs/stages"
+import { CATEGORIES } from "../../web/static/js/configs/retro_configs"
 
 const { IDEA_GENERATION, VOTING, ACTION_ITEMS, CLOSED } = STAGES
 
@@ -45,6 +46,7 @@ describe("CategoryColumn", () => {
           ideas={ideas}
           category="confused"
           stage={IDEA_GENERATION}
+          categories={CATEGORIES}
         />
       )
 
@@ -58,6 +60,7 @@ describe("CategoryColumn", () => {
           {...defaultProps}
           ideas={ideas}
           stage={VOTING}
+          categories={CATEGORIES}
         />
       )
 
@@ -100,6 +103,7 @@ describe("CategoryColumn", () => {
             ideas={ideas}
             votes={votes}
             stage={ACTION_ITEMS}
+            categories={CATEGORIES}
           />
         )
 
@@ -109,6 +113,7 @@ describe("CategoryColumn", () => {
             ideas={ideas}
             votes={votes}
             stage={CLOSED}
+            categories={CATEGORIES}
           />
         )
 
@@ -153,6 +158,7 @@ describe("CategoryColumn", () => {
               ideas={ideas}
               votes={votes}
               stage={ACTION_ITEMS}
+              categories={CATEGORIES}
             />
           )
 
@@ -189,6 +195,7 @@ describe("CategoryColumn", () => {
             ideas={ideas}
             category="action-item"
             stage={ACTION_ITEMS}
+            categories={CATEGORIES}
           />
         )
 
@@ -234,6 +241,7 @@ describe("CategoryColumn", () => {
           votes={votes}
           ideas={ideas}
           stage={VOTING}
+          categories={CATEGORIES}
         />
       )
 
@@ -266,6 +274,7 @@ describe("CategoryColumn", () => {
           {...defaultProps}
           ideas={ideas}
           category="happy"
+          categories={CATEGORIES}
         />
       )
       expect(wrapper.find(Idea)).to.have.length(2)
@@ -287,6 +296,7 @@ describe("CategoryColumn", () => {
           {...defaultProps}
           ideas={ideas}
           category={differentCategory}
+          categories={CATEGORIES}
         />
       )
 

--- a/test/components/idea_test.js
+++ b/test/components/idea_test.js
@@ -5,6 +5,7 @@ import Idea from "../../web/static/js/components/idea"
 import IdeaControls from "../../web/static/js/components/idea_controls"
 import IdeaEditForm from "../../web/static/js/components/idea_edit_form"
 import STAGES from "../../web/static/js/configs/stages"
+import { CATEGORIES } from "../../web/static/js/configs/retro_configs"
 
 const { IDEA_GENERATION, CLOSED } = STAGES
 
@@ -28,6 +29,8 @@ describe("Idea component", () => {
         currentUser={facilitatorUser}
         retroChannel={mockRetroChannel}
         stage={IDEA_GENERATION}
+        category={idea.category}
+        categories={CATEGORIES}
       />
     )
 
@@ -46,6 +49,8 @@ describe("Idea component", () => {
           currentUser={facilitatorUser}
           retroChannel={mockRetroChannel}
           stage={CLOSED}
+          category={idea.category}
+          categories={CATEGORIES}
         />
       )
 
@@ -64,6 +69,8 @@ describe("Idea component", () => {
         currentUser={mockUser}
         retroChannel={mockRetroChannel}
         stage={IDEA_GENERATION}
+        category={idea.category}
+        categories={CATEGORIES}
       />
     )
 
@@ -85,6 +92,8 @@ describe("Idea component", () => {
         currentUser={mockUser}
         retroChannel={mockRetroChannel}
         stage={IDEA_GENERATION}
+        category={idea.category}
+        categories={CATEGORIES}
       />
     )
 
@@ -102,6 +111,8 @@ describe("Idea component", () => {
           currentUser={facilitatorUser}
           retroChannel={mockRetroChannel}
           stage={IDEA_GENERATION}
+          category={idea.category}
+          categories={CATEGORIES}
         />
       )
 
@@ -122,6 +133,8 @@ describe("Idea component", () => {
           currentUser={nonFacilitatorUser}
           retroChannel={mockRetroChannel}
           stage={IDEA_GENERATION}
+          category={idea.category}
+          categories={CATEGORIES}
         />
       )
 
@@ -140,6 +153,8 @@ describe("Idea component", () => {
             currentUser={nonFacilitatorUser}
             retroChannel={mockRetroChannel}
             stage={IDEA_GENERATION}
+            category={idea.category}
+            categories={CATEGORIES}
           />
         )
         it("displays the `liveEditText` value rather than the body value", () => {
@@ -165,6 +180,8 @@ describe("Idea component", () => {
         currentUser={mockUser}
         retroChannel={mockRetroChannel}
         stage={IDEA_GENERATION}
+        category={idea.category}
+        categories={CATEGORIES}
       />
     )
 

--- a/web/channels/retro_channel.ex
+++ b/web/channels/retro_channel.ex
@@ -58,9 +58,10 @@ defmodule RemoteRetro.RetroChannel do
   end
 
   def handle_in("idea_edited", %{"id" => id, "body" => body, "category" => category}, socket) do
+    ideaEx = Repo.get(Idea, id)
     idea =
       Repo.get(Idea, id)
-      |> Idea.changeset(%{body: body, category: category})
+      |> Idea.changeset(%{body: body || ideaEx.body, category: category || ideaEx.category})
       |> Repo.update!
 
     broadcast! socket, "idea_edited", idea

--- a/web/channels/retro_channel.ex
+++ b/web/channels/retro_channel.ex
@@ -57,10 +57,10 @@ defmodule RemoteRetro.RetroChannel do
     {:noreply, socket}
   end
 
-  def handle_in("idea_edited", %{"id" => id, "body" => body}, socket) do
+  def handle_in("idea_edited", %{"id" => id, "body" => body, "category" => category}, socket) do
     idea =
       Repo.get(Idea, id)
-      |> Idea.changeset(%{body: body})
+      |> Idea.changeset(%{body: body, category: category})
       |> Repo.update!
 
     broadcast! socket, "idea_edited", idea

--- a/web/static/js/components/idea.jsx
+++ b/web/static/js/components/idea.jsx
@@ -33,7 +33,12 @@ const Idea = props => {
   )
 
   const ideaEditForm = (
-    <IdeaEditForm idea={idea} retroChannel={retroChannel} categories={categories} />
+    <IdeaEditForm
+      idea={idea}
+      retroChannel={retroChannel}
+      categories={categories}
+      stage={stage}
+    />
   )
 
   const renderIdeaControls = () => {

--- a/web/static/js/components/idea.jsx
+++ b/web/static/js/components/idea.jsx
@@ -10,7 +10,7 @@ import STAGES from "../configs/stages"
 const { CLOSED } = STAGES
 
 const Idea = props => {
-  const { idea, currentUser, retroChannel, stage } = props
+  const { idea, currentUser, retroChannel, stage, categories } = props
   const isFacilitator = currentUser.is_facilitator
   const isEdited = (+new Date(idea.updated_at) - +new Date(idea.inserted_at)) > 1000
   const classes = classNames({
@@ -33,7 +33,7 @@ const Idea = props => {
   )
 
   const ideaEditForm = (
-    <IdeaEditForm idea={idea} retroChannel={retroChannel} />
+    <IdeaEditForm idea={idea} retroChannel={retroChannel} categories={categories} />
   )
 
   const renderIdeaControls = () => {

--- a/web/static/js/components/idea.jsx
+++ b/web/static/js/components/idea.jsx
@@ -10,7 +10,7 @@ import STAGES from "../configs/stages"
 const { CLOSED } = STAGES
 
 const Idea = props => {
-  const { idea, currentUser, retroChannel, stage, categories } = props
+  const { idea, currentUser, retroChannel, stage, categories, category } = props
   const isFacilitator = currentUser.is_facilitator
   const isEdited = (+new Date(idea.updated_at) - +new Date(idea.inserted_at)) > 1000
   const classes = classNames({
@@ -37,6 +37,7 @@ const Idea = props => {
       idea={idea}
       retroChannel={retroChannel}
       categories={categories}
+      category={category}
       stage={stage}
     />
   )

--- a/web/static/js/components/idea.jsx
+++ b/web/static/js/components/idea.jsx
@@ -87,6 +87,8 @@ Idea.propTypes = {
   retroChannel: AppPropTypes.retroChannel.isRequired,
   currentUser: AppPropTypes.user.isRequired,
   stage: AppPropTypes.stage.isRequired,
+  category: AppPropTypes.category.isRequired,
+  categories: AppPropTypes.categories.isRequired,
 }
 
 export default Idea

--- a/web/static/js/components/idea_edit_form.jsx
+++ b/web/static/js/components/idea_edit_form.jsx
@@ -26,7 +26,12 @@ class IdeaEditForm extends Component {
     event.preventDefault()
     const { idea, retroChannel } = this.props
     const { ideaBody } = this.state
-    retroChannel.push("idea_edited", { id: idea.id, body: ideaBody })
+    const ideaCategory = "sad"
+    retroChannel.push("idea_edited", {
+      id: idea.id,
+      body: ideaBody,
+      category: ideaCategory,
+    })
   }
 
   render() {

--- a/web/static/js/components/idea_edit_form.jsx
+++ b/web/static/js/components/idea_edit_form.jsx
@@ -4,7 +4,10 @@ import * as AppPropTypes from "../prop_types"
 class IdeaEditForm extends Component {
   constructor(props) {
     super(props)
-    this.state = { ideaBody: props.idea.body }
+    this.state = {
+      ideaBody: props.idea.body,
+      ideaCategory: props.category,
+    }
     this.onChange = this.onChange.bind(this)
     this.onSubmit = this.onSubmit.bind(this)
     this.onCancel = this.onCancel.bind(this)
@@ -12,8 +15,12 @@ class IdeaEditForm extends Component {
 
   onChange(event) {
     const { retroChannel, idea } = this.props
-    retroChannel.push("idea_live_edit", { id: idea.id, liveEditText: event.target.value })
-    this.setState({ ideaBody: event.target.value })
+    if (event.target.name === "editable_idea") {
+      retroChannel.push("idea_live_edit", { id: idea.id, liveEditText: event.target.value })
+      this.setState({ ideaBody: event.target.value })
+    } else if (event.target.name === "editable_category") {
+      this.setState({ ideaCategory: event.target.value })
+    }
   }
 
   onCancel(event) {
@@ -25,8 +32,7 @@ class IdeaEditForm extends Component {
   onSubmit(event) {
     event.preventDefault()
     const { idea, retroChannel } = this.props
-    const { ideaBody } = this.state
-    const ideaCategory = "sad"
+    const { ideaBody, ideaCategory } = this.state
     retroChannel.push("idea_edited", {
       id: idea.id,
       body: ideaBody,
@@ -35,12 +41,16 @@ class IdeaEditForm extends Component {
   }
 
   render() {
-    const { categories, category, stage } = this.props
+    const { categories, stage } = this.props
     return (
       <form onSubmit={this.onSubmit} className="ui form">
         <p className="ui center aligned sub header">Editing</p>
-        {stage !== "action-items" && <select className="ui dropdown">
-          <option value="">{category}</option>
+        {stage !== "action-items" && <select
+          name="editable_category"
+          className="ui dropdown"
+          onChange={this.onChange}
+          value={this.state.ideaCategory}
+        >
           {categories.map(category => (
             <option key={category} value={category}>{category}</option>
           ))}
@@ -67,6 +77,9 @@ class IdeaEditForm extends Component {
 IdeaEditForm.propTypes = {
   idea: AppPropTypes.idea.isRequired,
   retroChannel: AppPropTypes.retroChannel.isRequired,
+  category: AppPropTypes.category.isRequired,
+  categories: AppPropTypes.categories.isRequired,
+  stage: AppPropTypes.stage.isRequired,
 }
 
 export default IdeaEditForm

--- a/web/static/js/components/idea_edit_form.jsx
+++ b/web/static/js/components/idea_edit_form.jsx
@@ -30,14 +30,15 @@ class IdeaEditForm extends Component {
   }
 
   render() {
+    const categories = this.props.categories
     return (
       <form onSubmit={this.onSubmit} className="ui form">
         <p className="ui center aligned sub header">Editing</p>
         <select className="ui dropdown">
           <option value="">Category</option>
-          <option value="happy">Happy</option>
-          <option value="sad">Sad</option>
-          <option value="confused">confused</option>
+          {categories.map(category => (
+            <option key={category} value={category}>{category}</option>
+          ))}
         </select>
         <div className="field">
           <textarea

--- a/web/static/js/components/idea_edit_form.jsx
+++ b/web/static/js/components/idea_edit_form.jsx
@@ -30,16 +30,16 @@ class IdeaEditForm extends Component {
   }
 
   render() {
-    const categories = this.props.categories
+    const { categories, stage } = this.props
     return (
       <form onSubmit={this.onSubmit} className="ui form">
         <p className="ui center aligned sub header">Editing</p>
-        <select className="ui dropdown">
+        {stage !== "action-items" && <select className="ui dropdown">
           <option value="">Category</option>
           {categories.map(category => (
             <option key={category} value={category}>{category}</option>
           ))}
-        </select>
+        </select>}
         <div className="field">
           <textarea
             name="editable_idea"

--- a/web/static/js/components/idea_edit_form.jsx
+++ b/web/static/js/components/idea_edit_form.jsx
@@ -33,6 +33,12 @@ class IdeaEditForm extends Component {
     return (
       <form onSubmit={this.onSubmit} className="ui form">
         <p className="ui center aligned sub header">Editing</p>
+        <select className="ui dropdown">
+          <option value="">Category</option>
+          <option value="happy">Happy</option>
+          <option value="sad">Sad</option>
+          <option value="confused">confused</option>
+        </select>
         <div className="field">
           <textarea
             name="editable_idea"

--- a/web/static/js/components/idea_edit_form.jsx
+++ b/web/static/js/components/idea_edit_form.jsx
@@ -30,12 +30,12 @@ class IdeaEditForm extends Component {
   }
 
   render() {
-    const { categories, stage } = this.props
+    const { categories, category, stage } = this.props
     return (
       <form onSubmit={this.onSubmit} className="ui form">
         <p className="ui center aligned sub header">Editing</p>
         {stage !== "action-items" && <select className="ui dropdown">
-          <option value="">Category</option>
+          <option value="">{category}</option>
           {categories.map(category => (
             <option key={category} value={category}>{category}</option>
           ))}


### PR DESCRIPTION
This PR allows the facilitator to re-classify an idea to another category.

__Dependencies Introduced or Upgraded:__  n/a

__Description of Testing Applied:__  tests have been modifying/updated accordingly

__Relevant Screenshots/GIFs:__  
![image](https://user-images.githubusercontent.com/8727588/33618770-6e908a3e-d9b1-11e7-8b76-7009f70b3435.png)

__Relevant github Issue:__  325

- [issue 325](https://github.com/stride-nyc/remote_retro/issues/325)
