### PR TITLE
Bugfix/avoid overlap in voting phase - story# 333

### DIFF
--- a/test/components/lower_third_test.js
+++ b/test/components/lower_third_test.js
@@ -5,6 +5,7 @@ import { spy } from "sinon"
 import LowerThird from "../../web/static/js/components/lower_third"
 import IdeaGenerationLowerThirdContent from "../../web/static/js/components/idea_generation_lower_third_content" // eslint-disable-line line-length
 import VotingLowerThirdContent from "../../web/static/js/components/voting_lower_third_content"
+import StageProgressionButton from "../../web/static/js/components/stage_progression_button"
 import STAGES from "../../web/static/js/configs/stages"
 
 const { IDEA_GENERATION, VOTING, CLOSED } = STAGES
@@ -57,6 +58,34 @@ describe("LowerThird component", () => {
 
       expect(lowerThird.find(VotingLowerThirdContent)).to.have.length(1)
       expect(lowerThird.find(IdeaGenerationLowerThirdContent)).to.have.length(0)
+    })
+
+    context("when the user is the facilitator", () => {
+      it("renders the 'Proceed to Action Items button", () => {
+        const currentUser = { is_facilitator: true }
+        const lowerThird = mountWithConnectedSubcomponents(
+          <LowerThird
+            {...defaultProps}
+            currentUser={currentUser}
+            stage={VOTING}
+          />
+        )
+        expect(lowerThird.find(StageProgressionButton)).to.have.length(1)
+      })
+    })
+
+    context("when the user is not the facilitator", () => {
+      it("does not render the 'Proceed to Action Items button", () => {
+        const currentUser = { is_facilitator: false }
+        const lowerThird = mountWithConnectedSubcomponents(
+          <LowerThird
+            {...defaultProps}
+            currentUser={currentUser}
+            stage={VOTING}
+          />
+        )
+        expect(lowerThird.find(StageProgressionButton)).to.have.length(0)
+      })
     })
   })
 })

--- a/web/static/js/components/voting_lower_third_content.jsx
+++ b/web/static/js/components/voting_lower_third_content.jsx
@@ -7,8 +7,10 @@ import * as AppPropTypes from "../prop_types"
 
 const VotingLowerThirdContent = props => (
   <div className="ui stackable grid basic attached secondary center aligned segment">
-    <VotesLeft currentUser={props.currentUser} />
-    <div className="five wide computer eight wide tablet column">
+    <div className="two wide column">
+      <VotesLeft currentUser={props.currentUser} />
+    </div>
+    <div className="four wide column">
       <StageProgressionButton {...props} />
     </div>
   </div>

--- a/web/static/js/components/voting_lower_third_content.jsx
+++ b/web/static/js/components/voting_lower_third_content.jsx
@@ -7,10 +7,11 @@ import * as AppPropTypes from "../prop_types"
 
 const VotingLowerThirdContent = props => (
   <div className="ui stackable grid basic attached secondary center aligned segment">
-    <div className="two wide column">
+    <div className="three wide column" />
+    <div className="ten wide column">
       <VotesLeft currentUser={props.currentUser} />
     </div>
-    {props.currentUser.is_facilitator && <div className="four wide column">
+    {props.currentUser.is_facilitator && <div className="three wide column">
       <StageProgressionButton {...props} />
     </div>
     }

--- a/web/static/js/components/voting_lower_third_content.jsx
+++ b/web/static/js/components/voting_lower_third_content.jsx
@@ -10,9 +10,10 @@ const VotingLowerThirdContent = props => (
     <div className="two wide column">
       <VotesLeft currentUser={props.currentUser} />
     </div>
-    <div className="four wide column">
+    {props.currentUser.is_facilitator && <div className="four wide column">
       <StageProgressionButton {...props} />
     </div>
+    }
   </div>
 )
 


### PR DESCRIPTION
This PR introduces a bug fix for the overlap of participants and the ideas during the voting phase.

__Dependencies Introduced or Upgraded:__ n/a

__Description of Testing Applied:__ tests were updated for the conditional rendering

__Relevant Screenshots/GIFs:__ 
facilitator's view: 
![image](https://user-images.githubusercontent.com/8727588/33858615-4ea9d224-de9e-11e7-95a7-5f934385c536.png)


non-facilitator's view:
![image](https://user-images.githubusercontent.com/8727588/33858627-59da2dc4-de9e-11e7-90c4-78f697847f59.png)

__Relevant github Issue:__

- [333](https://github.com/stride-nyc/remote_retro/issues/333)
