### PR TITLE
Disallow facilitators from acting on idea while it is being edited by its author

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -65,5 +65,6 @@ module.exports = {
     "react/forbid-prop-types": "off",
     "jsx-a11y/no-static-element-interactions": 0,
     "import/no-named-as-default": "off",
+    "no-unused-expressions": ["error", {"allowTernary": true}],
   }
 }

--- a/test/components/idea_controls_test.js
+++ b/test/components/idea_controls_test.js
@@ -42,7 +42,10 @@ describe("<IdeaControls />", () => {
           />
         )
 
-        wrapper.find(".remove.icon").simulate("click")
+        const removalIcon = wrapper.find(".remove.icon")
+        expect(removalIcon.prop("title")).to.equal("Delete Idea")
+
+        removalIcon.simulate("click")
         expect(
           retroChannel.push.calledWith("delete_idea", 666)
         ).to.equal(true)
@@ -50,7 +53,7 @@ describe("<IdeaControls />", () => {
     })
 
     context("when the idea is currently being edited by its author", () => {
-      it("does nothing", () => {
+      it("performs no action while displaying 'Author currently editing' on hover", () => {
         idea.editing = true
         const retroChannel = { on: () => { }, push: sinon.spy() }
 
@@ -63,7 +66,10 @@ describe("<IdeaControls />", () => {
           />
         )
 
-        wrapper.find(".remove.icon").simulate("click")
+        const removalIcon = wrapper.find(".remove.icon")
+        expect(removalIcon.prop("title")).to.equal("Author currently editing")
+
+        removalIcon.simulate("click")
         expect(
           retroChannel.push.calledWith("delete_idea", 666)
         ).to.equal(false)
@@ -86,7 +92,10 @@ describe("<IdeaControls />", () => {
           />
         )
 
-        wrapper.find(".edit.icon").simulate("click")
+        const editIcon = wrapper.find(".edit.icon")
+        expect(editIcon.prop("title")).to.equal("Edit Idea")
+
+        editIcon.simulate("click")
         expect(
           retroChannel.push.calledWith("enable_edit_state", { idea, editorToken: mockUser.token })
         ).to.equal(true)
@@ -94,7 +103,7 @@ describe("<IdeaControls />", () => {
     })
 
     context("when the idea is currently being edited by its author", () => {
-      it("does nothing", () => {
+      it("performs no action while displaying 'Author currently editing' on hover", () => {
         idea.editing = true
         const retroChannel = { on: () => { }, push: sinon.spy() }
 
@@ -107,7 +116,10 @@ describe("<IdeaControls />", () => {
           />
         )
 
-        wrapper.find(".edit.icon").simulate("click")
+        const editIcon = wrapper.find(".edit.icon")
+        expect(editIcon.prop("title")).to.equal("Author currently editing")
+
+        editIcon.simulate("click")
         expect(
           retroChannel.push.calledWith("enable_edit_state", { idea, editorToken: mockUser.token })
         ).to.equal(false)

--- a/test/components/idea_controls_test.js
+++ b/test/components/idea_controls_test.js
@@ -28,42 +28,90 @@ describe("<IdeaControls />", () => {
   })
 
   describe("on click of the removal icon", () => {
-    it("pushes an `delete_idea` event to the retro channel, passing the given idea's id", () => {
-      const retroChannel = { on: () => {}, push: sinon.spy() }
+    context("when the idea is not currently being edited by its author", () => {
+      it("pushes an `delete_idea` event to the retro channel, passing the given idea's id", () => {
+        idea.editing = false
+        const retroChannel = { on: () => { }, push: sinon.spy() }
 
-      const wrapper = shallow(
-        <IdeaControls
-          idea={idea}
-          retroChannel={retroChannel}
-          currentUser={mockUser}
-          stage={IDEA_GENERATION}
-        />
-      )
+        const wrapper = shallow(
+          <IdeaControls
+            idea={idea}
+            retroChannel={retroChannel}
+            currentUser={mockUser}
+            stage={IDEA_GENERATION}
+          />
+        )
 
-      wrapper.find(".remove.icon").simulate("click")
-      expect(
-        retroChannel.push.calledWith("delete_idea", 666)
-      ).to.equal(true)
+        wrapper.find(".remove.icon").simulate("click")
+        expect(
+          retroChannel.push.calledWith("delete_idea", 666)
+        ).to.equal(true)
+      })
+    })
+
+    context("when the idea is currently being edited by its author", () => {
+      it("does nothing", () => {
+        idea.editing = true
+        const retroChannel = { on: () => { }, push: sinon.spy() }
+
+        const wrapper = shallow(
+          <IdeaControls
+            idea={idea}
+            retroChannel={retroChannel}
+            currentUser={mockUser}
+            stage={IDEA_GENERATION}
+          />
+        )
+
+        wrapper.find(".remove.icon").simulate("click")
+        expect(
+          retroChannel.push.calledWith("delete_idea", 666)
+        ).to.equal(false)
+      })
     })
   })
 
   describe("on click of the edit icon", () => {
-    it("pushes an enable_edit_state event to the channel, passing the idea and editorToken", () => {
-      const retroChannel = { on: () => {}, push: sinon.spy() }
+    context("when the idea is not currently being edited by its author", () => {
+      it("pushes an enable_edit_state event to the channel, passing the idea and editorToken", () => {
+        idea.editing = false
+        const retroChannel = { on: () => { }, push: sinon.spy() }
 
-      const wrapper = shallow(
-        <IdeaControls
-          idea={idea}
-          retroChannel={retroChannel}
-          currentUser={mockUser}
-          stage={IDEA_GENERATION}
-        />
-      )
+        const wrapper = shallow(
+          <IdeaControls
+            idea={idea}
+            retroChannel={retroChannel}
+            currentUser={mockUser}
+            stage={IDEA_GENERATION}
+          />
+        )
 
-      wrapper.find(".edit.icon").simulate("click")
-      expect(
-        retroChannel.push.calledWith("enable_edit_state", { idea, editorToken: mockUser.token })
-      ).to.equal(true)
+        wrapper.find(".edit.icon").simulate("click")
+        expect(
+          retroChannel.push.calledWith("enable_edit_state", { idea, editorToken: mockUser.token })
+        ).to.equal(true)
+      })
+    })
+
+    context("when the idea is currently being edited by its author", () => {
+      it("does nothing", () => {
+        idea.editing = true
+        const retroChannel = { on: () => { }, push: sinon.spy() }
+
+        const wrapper = shallow(
+          <IdeaControls
+            idea={idea}
+            retroChannel={retroChannel}
+            currentUser={mockUser}
+            stage={IDEA_GENERATION}
+          />
+        )
+
+        wrapper.find(".edit.icon").simulate("click")
+        expect(
+          retroChannel.push.calledWith("enable_edit_state", { idea, editorToken: mockUser.token })
+        ).to.equal(false)
+      })
     })
   })
 

--- a/test/components/idea_controls_test.js
+++ b/test/components/idea_controls_test.js
@@ -30,7 +30,7 @@ describe("<IdeaControls />", () => {
   describe("on click of the removal icon", () => {
     context("when the idea is not currently being edited by its author", () => {
       it("pushes an `delete_idea` event to the retro channel, passing the given idea's id", () => {
-        idea.editing = false
+        const idea = { id: 666, category: "sad", body: "redundant tests", user_id: 1, editing: false }
         const retroChannel = { on: () => { }, push: sinon.spy() }
 
         const wrapper = shallow(
@@ -54,7 +54,7 @@ describe("<IdeaControls />", () => {
 
     context("when the idea is currently being edited by its author", () => {
       it("performs no action while displaying 'Author currently editing' on hover", () => {
-        idea.editing = true
+        const idea = { id: 666, category: "sad", body: "redundant tests", user_id: 1, editing: true }
         const retroChannel = { on: () => { }, push: sinon.spy() }
 
         const wrapper = shallow(
@@ -80,7 +80,7 @@ describe("<IdeaControls />", () => {
   describe("on click of the edit icon", () => {
     context("when the idea is not currently being edited by its author", () => {
       it("pushes an enable_edit_state event to the channel, passing the idea and editorToken", () => {
-        idea.editing = false
+        const idea = { id: 666, category: "sad", body: "redundant tests", user_id: 1, editing: false }
         const retroChannel = { on: () => { }, push: sinon.spy() }
 
         const wrapper = shallow(
@@ -104,7 +104,7 @@ describe("<IdeaControls />", () => {
 
     context("when the idea is currently being edited by its author", () => {
       it("performs no action while displaying 'Author currently editing' on hover", () => {
-        idea.editing = true
+        const idea = { id: 666, category: "sad", body: "redundant tests", user_id: 1, editing: true }
         const retroChannel = { on: () => { }, push: sinon.spy() }
 
         const wrapper = shallow(
@@ -128,22 +128,46 @@ describe("<IdeaControls />", () => {
   })
 
   describe("on click of the announcement icon", () => {
-    it("pushes a `highlight_idea` event to the retro channel, passing the given idea's id and highlight state", () => {
-      const retroChannel = { on: () => {}, push: sinon.spy() }
+    context("when the idea is not currently being edited by its author", () => {
+      it("pushes a `highlight_idea` event to the retro channel, passing the given idea's id and highlight state", () => {
+        const retroChannel = { on: () => { }, push: sinon.spy() }
+        const idea = { id: 666, category: "sad", body: "redundant tests", user_id: 1, editing: false }
 
-      const wrapper = shallow(
-        <IdeaControls
-          idea={idea}
-          retroChannel={retroChannel}
-          currentUser={mockUser}
-          stage={IDEA_GENERATION}
-        />
-      )
+        const wrapper = shallow(
+          <IdeaControls
+            idea={idea}
+            retroChannel={retroChannel}
+            currentUser={mockUser}
+            stage={IDEA_GENERATION}
+          />
+        )
 
-      wrapper.find(".announcement.icon").simulate("click")
-      expect(
-        retroChannel.push.calledWith("highlight_idea", { id: 666, isHighlighted: false })
-      ).to.equal(true)
+        wrapper.find(".announcement.icon").simulate("click")
+        expect(
+          retroChannel.push.calledWith("highlight_idea", { id: 666, isHighlighted: false })
+        ).to.equal(true)
+      })
+    })
+
+    context("when the idea is currently being edited by its author", () => {
+      it("pushes a `highlight_idea` event to the retro channel, passing the given idea's id and highlight state", () => {
+        const retroChannel = { on: () => { }, push: sinon.spy() }
+        const idea = { id: 666, category: "sad", body: "redundant tests", user_id: 1, editing: true }
+
+        const wrapper = shallow(
+          <IdeaControls
+            idea={idea}
+            retroChannel={retroChannel}
+            currentUser={mockUser}
+            stage={IDEA_GENERATION}
+          />
+        )
+
+        wrapper.find(".announcement.icon").simulate("click")
+        expect(
+          retroChannel.push.calledWith("highlight_idea", { id: 666, isHighlighted: false })
+        ).to.equal(false)
+      })
     })
   })
 

--- a/web/static/js/components/idea_controls.jsx
+++ b/web/static/js/components/idea_controls.jsx
@@ -39,29 +39,26 @@ export const IdeaControls = props => {
     }
 
     if (currentUser.is_facilitator || currentUser.id === userId) {
-      const iconStyle = { color: idea.editing ? "lightgray" : "black" }
       const authorEditing = "Author currently editing"
       const noOp = () => {}
       return (
         <div className={styles.wrapper}>
           <i
             title={idea.editing ? authorEditing : "Delete Idea"}
-            className={`${styles.actionIcon} remove circle icon`}
+            className={`${styles.actionIcon} remove circle icon ${idea.editing ? "disabled" : ""}`}
             onClick={() => { idea.editing ? noOp() : retroChannel.push("delete_idea", idea.id) }}
-            style={iconStyle}
           />
           <i
             title={idea.editing ? authorEditing : "Edit Idea"}
-            className={`${styles.actionIcon} edit icon`}
+            className={`${styles.actionIcon} edit icon ${idea.editing ? "disabled" : ""}`}
             onClick={() => { idea.editing ? noOp() : retroChannel.push("enable_edit_state", { idea, editorToken: currentUser.token }) }}
-            style={iconStyle}
           />
           {
             currentUser.is_facilitator &&
             <i
               title={highlightTitle}
-              className={highlightClasses}
-              onClick={() => { retroChannel.push("highlight_idea", { id, isHighlighted }) }}
+              className={`${highlightClasses} ${idea.editing ? "disabled" : ""}`}
+              onClick={() => { idea.editing ? noOp() : retroChannel.push("highlight_idea", { id, isHighlighted }) }}
             />
           }
         </div>

--- a/web/static/js/components/idea_controls.jsx
+++ b/web/static/js/components/idea_controls.jsx
@@ -44,13 +44,13 @@ export const IdeaControls = props => {
       return (
         <div className={styles.wrapper}>
           <i
-            title="Delete Idea"
+            title={idea.editing ? "Author currently editing" : "Delete Idea"}
             className={`${styles.actionIcon} remove circle icon`}
             onClick={() => { idea.editing ? noOp() : retroChannel.push("delete_idea", idea.id) }}
             style={iconStyle}
           />
           <i
-            title="Edit Idea"
+            title={idea.editing ? "Author currently editing" : "Edit Idea"}
             className={`${styles.actionIcon} edit icon`}
             onClick={() => { idea.editing ? noOp() : retroChannel.push("enable_edit_state", { idea, editorToken: currentUser.token }) }}
             style={iconStyle}

--- a/web/static/js/components/idea_controls.jsx
+++ b/web/static/js/components/idea_controls.jsx
@@ -40,17 +40,18 @@ export const IdeaControls = props => {
 
     if (currentUser.is_facilitator || currentUser.id === userId) {
       const iconStyle = { color: idea.editing ? "lightgray" : "black" }
+      const authorEditing = "Author currently editing"
       const noOp = () => {}
       return (
         <div className={styles.wrapper}>
           <i
-            title={idea.editing ? "Author currently editing" : "Delete Idea"}
+            title={idea.editing ? authorEditing : "Delete Idea"}
             className={`${styles.actionIcon} remove circle icon`}
             onClick={() => { idea.editing ? noOp() : retroChannel.push("delete_idea", idea.id) }}
             style={iconStyle}
           />
           <i
-            title={idea.editing ? "Author currently editing" : "Edit Idea"}
+            title={idea.editing ? authorEditing : "Edit Idea"}
             className={`${styles.actionIcon} edit icon`}
             onClick={() => { idea.editing ? noOp() : retroChannel.push("enable_edit_state", { idea, editorToken: currentUser.token }) }}
             style={iconStyle}

--- a/web/static/js/components/idea_controls.jsx
+++ b/web/static/js/components/idea_controls.jsx
@@ -39,17 +39,21 @@ export const IdeaControls = props => {
     }
 
     if (currentUser.is_facilitator || currentUser.id === userId) {
+      const iconStyle = { color: idea.editing ? "lightgray" : "black" }
+      const noOp = () => {}
       return (
         <div className={styles.wrapper}>
           <i
             title="Delete Idea"
             className={`${styles.actionIcon} remove circle icon`}
-            onClick={() => { retroChannel.push("delete_idea", idea.id) }}
+            onClick={() => { idea.editing ? noOp() : retroChannel.push("delete_idea", idea.id) }}
+            style={iconStyle}
           />
           <i
             title="Edit Idea"
             className={`${styles.actionIcon} edit icon`}
-            onClick={() => { retroChannel.push("enable_edit_state", { idea, editorToken: currentUser.token }) }}
+            onClick={() => { idea.editing ? noOp() : retroChannel.push("enable_edit_state", { idea, editorToken: currentUser.token }) }}
+            style={iconStyle}
           />
           {
             currentUser.is_facilitator &&


### PR DESCRIPTION
This PR introduces the following changes:
1) The facilitator's edit, delete, and spotlight idea control icons become disabled while the author is editing their idea
2) When hovering over the deactivated idea control icons, the title tooltip displays "Author currently editing"
3) When hovering over active idea control icons, the title tooltip displays "Delete Idea" or "Edit Idea", depending on the icon type.

__Dependencies Introduced or Upgraded:__ n/a

__Description of Testing Applied:__ Tests updated accordingly

__Relevant github Issue:__ 

- [331](https://github.com/stride-nyc/remote_retro/issues/331)
