### PR TITLE
Accessible idea list

### DIFF
--- a/web/static/js/components/category_column.jsx
+++ b/web/static/js/components/category_column.jsx
@@ -52,8 +52,9 @@ export class CategoryColumn extends Component {
         easing="ease"
         enterAnimation="none"
         leaveAnimation="none"
+        typeName={null}
       >
-        {sortedIdeas.map(idea => <div key={idea.id}><Idea {...this.props} idea={idea} /></div>)}
+        {sortedIdeas.map(idea => <Idea {...this.props} idea={idea} key={idea.id} />)}
       </FlipMove>
     )
 

--- a/web/static/js/components/idea.jsx
+++ b/web/static/js/components/idea.jsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { Component } from "react"
 import classNames from "classnames"
 
 import IdeaEditForm from "./idea_edit_form"
@@ -7,33 +7,35 @@ import IdeaReadOnlyContent from "./idea_read_only_content"
 import * as AppPropTypes from "../prop_types"
 import styles from "./css_modules/idea.css"
 
-const Idea = props => {
-  const { idea, currentUser, retroChannel, stage } = props
-  const classes = classNames(styles.index, {
-    [styles.highlighted]: idea.isHighlighted,
-  })
+export default class Idea extends Component {
+  render() {
+    const { idea, currentUser, retroChannel, stage } = this.props
+    const classes = classNames(styles.index, {
+      [styles.highlighted]: idea.isHighlighted,
+    })
 
-  const userIsEditing = idea.editing && idea.editorToken === currentUser.token
+    const userIsEditing = idea.editing && idea.editorToken === currentUser.token
 
-  let content
-  if (userIsEditing) {
-    content = (<IdeaEditForm
-      idea={idea}
-      retroChannel={retroChannel}
-      currentUser={currentUser}
-      stage={stage}
-    />)
-  } else if (idea.liveEditText) {
-    content = <IdeaLiveEditContent idea={idea} />
-  } else {
-    content = <IdeaReadOnlyContent {...props} />
+    let content
+    if (userIsEditing) {
+      content = (<IdeaEditForm
+        idea={idea}
+        retroChannel={retroChannel}
+        currentUser={currentUser}
+        stage={stage}
+      />)
+    } else if (idea.liveEditText) {
+      content = <IdeaLiveEditContent idea={idea} />
+    } else {
+      content = <IdeaReadOnlyContent {...this.props} />
+    }
+
+    return (
+      <li className={classes} title={idea.body} key={idea.id}>
+        { content }
+      </li>
+    )
   }
-
-  return (
-    <li className={classes} title={idea.body} key={idea.id}>
-      { content }
-    </li>
-  )
 }
 
 Idea.propTypes = {
@@ -43,4 +45,3 @@ Idea.propTypes = {
   stage: AppPropTypes.stage.isRequired,
 }
 
-export default Idea

--- a/web/static/js/components/idea_submission_form.jsx
+++ b/web/static/js/components/idea_submission_form.jsx
@@ -103,9 +103,9 @@ export class IdeaSubmissionForm extends Component {
           </div>
           <div className="eleven wide field">
             <div className="ui fluid action input">
-              <label htmlFor="idea-input-label" className="visually-hidden">Idea input</label>
+              <label htmlFor="idea-body-input" className="visually-hidden">Idea input</label>
               <input
-                id="idea-input-label"
+                id="idea-body-input"
                 type="text"
                 name="idea"
                 autoComplete="off"


### PR DESCRIPTION
__Description of Change(s) Introduced:__ 

Following up on #343 (and branched off of), this removes the wrapping elements inside an idea list.

It also boosts accessibility of the idea generation page to 97 (screenshot below).

__Relevant Screenshots/GIFs:__ (if applicable)

<img width="808" alt="screen shot 2017-12-15 at 12 34 24 pm" src="https://user-images.githubusercontent.com/1494758/34053307-5037fd70-e194-11e7-8510-d2f341264af2.png">
