### PR TITLE
Start Retros in Lobby Stage

### DIFF
--- a/priv/repo/migrations/20180105152248_add_lobby_stage.exs
+++ b/priv/repo/migrations/20180105152248_add_lobby_stage.exs
@@ -1,0 +1,15 @@
+defmodule RemoteRetro.Repo.Migrations.AddLobbyStage do
+  use Ecto.Migration
+
+  def up do
+    alter table(:retros) do
+      modify :stage, :string, default: "lobby"
+    end
+  end
+
+  def down do
+    alter table(:retros) do
+      modify :stage, :string, default: "prime-directive"
+    end
+  end
+end

--- a/test/components/lobby_stage_test.jsx
+++ b/test/components/lobby_stage_test.jsx
@@ -1,0 +1,40 @@
+import React from "react"
+import { shallow } from "enzyme"
+
+import LobbyStage, { instructionText } from "../../web/static/js/components/lobby_stage"
+
+describe("LobbyStage component", () => {
+  let wrapper
+  let props
+  const currentUser = {
+    given_name: "Carol",
+  }
+  const defaultProps = {
+    progressionConfig: {},
+    currentUser,
+    isFacilitator: false,
+    users: [],
+  }
+
+  context("when the currentUser is the facilitator", () => {
+    props = { ...defaultProps, isFacilitator: true }
+
+    it("contains the instructions specific to the facilitator", () => {
+      wrapper = shallow(<LobbyStage {...props} />)
+      const expectedText = instructionText(true, "Carol")
+
+      expect(wrapper.text()).to.include(expectedText)
+    })
+  })
+
+  context("when the currentUser is not the facilitator", () => {
+    props = { ...defaultProps }
+
+    it("contains the instructions specific to participants", () => {
+      wrapper = shallow(<LobbyStage {...props} />)
+      const expectedText = instructionText(false, "Carol")
+
+      expect(wrapper.text()).to.include(expectedText)
+    })
+  })
+})

--- a/test/components/room_test.js
+++ b/test/components/room_test.js
@@ -2,11 +2,12 @@ import React from "react"
 import { shallow } from "enzyme"
 
 import Room from "../../web/static/js/components/room"
+import LobbyStage from "../../web/static/js/components/lobby_stage"
 import PrimeDirectiveStage from "../../web/static/js/components/prime_directive_stage"
 import IdeaGenerationStage from "../../web/static/js/components/idea_generation_stage"
 import STAGES from "../../web/static/js/configs/stages"
 
-const { PRIME_DIRECTIVE, IDEA_GENERATION } = STAGES
+const { LOBBY, PRIME_DIRECTIVE, IDEA_GENERATION } = STAGES
 
 describe("Room", () => {
   let room
@@ -15,33 +16,46 @@ describe("Room", () => {
     online_at: 803,
     picture: "http://herpderp.com",
   }]
-  describe("when the stage is prime-directive", () => {
-    room = shallow(
-      <Room
-        stage={PRIME_DIRECTIVE}
-        users={users}
-      />
-    )
 
+  describe("when the stage is lobby", () => {
+    it("renders the LobbyStage", () => {
+      room = shallow(
+        <Room
+          stage={LOBBY}
+          users={users}
+        />
+      )
+      const lobbyStage = room.find(LobbyStage)
+
+      expect(lobbyStage).to.have.length(1)
+    })
+  })
+
+  describe("when the stage is prime-directive", () => {
     it("renders the PrimeDirectiveStage", () => {
+      room = shallow(
+        <Room
+          stage={PRIME_DIRECTIVE}
+          users={users}
+        />
+      )
       const primeDirectiveStage = room.find(PrimeDirectiveStage)
 
       expect(primeDirectiveStage).to.have.length(1)
     })
   })
 
-  describe("when the stage is not prime-directive", () => {
-    const ideaRoom = shallow(
-      <Room
-        stage={IDEA_GENERATION}
-        users={users}
-        ideas={[]}
-        retroChannel={{}}
-      />
-    )
-
+  describe("when the stage is not lobby or prime-directive", () => {
     it("renders the IdeaGenerationStage", () => {
-      const ideaGenerationStage = ideaRoom.find(IdeaGenerationStage)
+      room = shallow(
+        <Room
+          stage={IDEA_GENERATION}
+          users={users}
+          ideas={[]}
+          retroChannel={{}}
+        />
+      )
+      const ideaGenerationStage = room.find(IdeaGenerationStage)
 
       expect(ideaGenerationStage).to.have.length(1)
     })

--- a/test/features/stage_progression_realtime_update_test.exs
+++ b/test/features/stage_progression_realtime_update_test.exs
@@ -6,7 +6,6 @@ defmodule StageProgressionRealtimeUpdateTest do
     retro_path = "/retros/" <> retro.id
     facilitator_session = authenticate(facilitator_session) |> visit(retro_path)
     participant_session = authenticate(participant_session) |> visit(retro_path)
-    stub_js_confirms_for_phantomjs(facilitator_session)
 
     submit_idea(facilitator_session, %{category: "happy", body: "it works"})
 

--- a/web/models/retro.ex
+++ b/web/models/retro.ex
@@ -16,6 +16,6 @@ defmodule RemoteRetro.Retro do
   def changeset(struct, %{stage: _stage} = params \\ %{}) do
     struct
     |> cast(params, [:stage])
-    |> validate_inclusion(:stage, ["prime-directive", "idea-generation", "voting", "action-items", "closed"])
+    |> validate_inclusion(:stage, ["lobby", "prime-directive", "idea-generation", "voting", "action-items", "closed"])
   end
 end

--- a/web/static/js/components/css_modules/centered_text.css
+++ b/web/static/js/components/css_modules/centered_text.css
@@ -1,4 +1,4 @@
-.directive {
+.centered-text {
   padding: 10rem 0 5rem 0;
   margin: 0 auto;
 }

--- a/web/static/js/components/lobby_stage.jsx
+++ b/web/static/js/components/lobby_stage.jsx
@@ -1,0 +1,48 @@
+import React from "react"
+import PropTypes from "prop-types"
+
+import UserList from "./user_list"
+import StageProgressionButton from "./stage_progression_button"
+import ShareRetroLinkModal from "./share_retro_link_modal"
+import * as AppPropTypes from "../prop_types"
+
+const LobbyStage = props => {
+  const { progressionConfig, currentUser, isFacilitator, users } = props
+  const facilitator = users.find(user => user.is_facilitator)
+  const facilitatorName = facilitator ? facilitator.given_name : ""
+  let instructions = null
+  if (isFacilitator) {
+    instructions = "Once your party has arrived, it will be your responsibility to start the retro, which you can do by clicking the button below."
+  } else {
+    instructions = `Once your party has arrived, your facilitator, ${facilitatorName}, will begin the retro. Until then, hold tight!`
+  }
+
+  return (
+    <div className="ui centered grid">
+      <div className="row">
+        <h1>Retro Lobby</h1>
+        <p>
+          Hi, {currentUser.given_name}! Welcome to Remote Retro! {instructions}
+        </p>
+      </div>
+      <div className="row">
+        <UserList {...props} />
+      </div>
+      <div className="row">
+        <div className="thirteen wide mobile eight wide tablet four wide computer column">
+          <StageProgressionButton {...props} config={progressionConfig} />
+        </div>
+      </div>
+      <ShareRetroLinkModal />
+    </div>
+  )
+}
+
+LobbyStage.propTypes = {
+  progressionConfig: PropTypes.object.isRequired,
+  currentUser: AppPropTypes.user.isRequired,
+  isFacilitator: PropTypes.bool.isRequired,
+  users: AppPropTypes.users.isRequired,
+}
+
+export default LobbyStage

--- a/web/static/js/components/lobby_stage.jsx
+++ b/web/static/js/components/lobby_stage.jsx
@@ -5,6 +5,7 @@ import UserList from "./user_list"
 import StageProgressionButton from "./stage_progression_button"
 import ShareRetroLinkModal from "./share_retro_link_modal"
 import * as AppPropTypes from "../prop_types"
+import styles from "./css_modules/centered_text.css"
 
 const LobbyStage = props => {
   const { progressionConfig, currentUser, isFacilitator, users } = props
@@ -12,18 +13,21 @@ const LobbyStage = props => {
   const facilitatorName = facilitator ? facilitator.given_name : ""
   let instructions = null
   if (isFacilitator) {
-    instructions = "Once your party has arrived, it will be your responsibility to start the retro, which you can do by clicking the button below."
+    instructions = "it will be your responsibility to start the retro, which you can do by clicking the button below."
   } else {
-    instructions = `Once your party has arrived, your facilitator, ${facilitatorName}, will begin the retro. Until then, hold tight!`
+    instructions = `your facilitator, ${facilitatorName}, will begin the retro. Until then, hold tight!`
   }
 
   return (
     <div className="ui centered grid">
-      <div className="row">
-        <h1>Retro Lobby</h1>
-        <p>
-          Hi, {currentUser.given_name}! Welcome to Remote Retro! {instructions}
-        </p>
+      <div className="thirteen wide mobile eight wide tablet five wide computer column">
+        <div className={styles.centeredText}>
+          <h1 className="ui dividing header">Retro Lobby</h1>
+          <h5>
+            Hi, {currentUser.given_name}! Welcome to Remote Retro!
+            Once your party has arrived, {instructions}
+          </h5>
+        </div>
       </div>
       <div className="row">
         <UserList {...props} />

--- a/web/static/js/components/lobby_stage.jsx
+++ b/web/static/js/components/lobby_stage.jsx
@@ -7,16 +7,18 @@ import ShareRetroLinkModal from "./share_retro_link_modal"
 import * as AppPropTypes from "../prop_types"
 import styles from "./css_modules/centered_text.css"
 
+export const instructionText = (userIsFacilitator, facilitatorName) => {
+  if (userIsFacilitator) {
+    return "it will be your responsibility to start the retro, which you can do by clicking the button below."
+  }
+  return `your facilitator, ${facilitatorName}, will begin the retro. Until then, hold tight!`
+}
+
 const LobbyStage = props => {
   const { progressionConfig, currentUser, isFacilitator, users } = props
   const facilitator = users.find(user => user.is_facilitator)
   const facilitatorName = facilitator ? facilitator.given_name : ""
-  let instructions = null
-  if (isFacilitator) {
-    instructions = "it will be your responsibility to start the retro, which you can do by clicking the button below."
-  } else {
-    instructions = `your facilitator, ${facilitatorName}, will begin the retro. Until then, hold tight!`
-  }
+  const instructions = instructionText(isFacilitator, facilitatorName)
 
   return (
     <div className="ui centered grid">

--- a/web/static/js/components/prime_directive.jsx
+++ b/web/static/js/components/prime_directive.jsx
@@ -1,9 +1,9 @@
 import React from "react"
 
-import styles from "./css_modules/prime_directive.css"
+import styles from "./css_modules/centered_text.css"
 
 const PrimeDirective = () => (
-  <div className={styles.directive}>
+  <div className={styles.centeredText}>
     <h1 className="ui dividing header">The Prime Directive:</h1>
     <p>
       Regardless of what we discover,<br />

--- a/web/static/js/components/prime_directive_stage.jsx
+++ b/web/static/js/components/prime_directive_stage.jsx
@@ -2,7 +2,6 @@ import React from "react"
 import PropTypes from "prop-types"
 
 import UserList from "./user_list"
-import ShareRetroLinkModal from "./share_retro_link_modal"
 import StageProgressionButton from "./stage_progression_button"
 import PrimeDirective from "./prime_directive"
 
@@ -21,7 +20,6 @@ const PrimeDirectiveStage = props => {
           <StageProgressionButton {...props} config={progressionConfig} />
         </div>
       </div>
-      <ShareRetroLinkModal />
     </div>
   )
 }

--- a/web/static/js/components/room.jsx
+++ b/web/static/js/components/room.jsx
@@ -1,18 +1,28 @@
 import React from "react"
 import PrimeDirectiveStage from "./prime_directive_stage"
+import LobbyStage from "./lobby_stage"
 import IdeaGenerationStage from "./idea_generation_stage"
 import stageConfigs from "../configs/stage_configs"
 import STAGES from "../configs/stages"
 
 import * as AppPropTypes from "../prop_types"
 
-const { PRIME_DIRECTIVE } = STAGES
+const { LOBBY, PRIME_DIRECTIVE } = STAGES
 
 const Room = props => {
   let roomContents
-  if (props.stage === PRIME_DIRECTIVE) {
-    const isFacilitator = props.currentUser.is_facilitator
-    const stageConfig = stageConfigs[props.stage]
+  const { stage, currentUser: { is_facilitator: isFacilitator } } = props
+  const stageConfig = stageConfigs[stage]
+
+  if (stage === LOBBY) {
+    roomContents = (
+      <LobbyStage
+        {...props}
+        progressionConfig={stageConfig}
+        isFacilitator={isFacilitator}
+      />
+    )
+  } else if (stage === PRIME_DIRECTIVE) {
     roomContents = (
       <PrimeDirectiveStage
         {...props}

--- a/web/static/js/components/stage_change_info_prime_directive.jsx
+++ b/web/static/js/components/stage_change_info_prime_directive.jsx
@@ -1,0 +1,9 @@
+import React from "react"
+
+export default () => (
+  <p>
+    The Prime Directive is used to frame the retrospective, such that the time
+    spent is as constructive as possible. Read it for yourself, and try to keep
+    it in mind as the retro moves forward
+  </p>
+)

--- a/web/static/js/configs/stage_configs.jsx
+++ b/web/static/js/configs/stage_configs.jsx
@@ -2,14 +2,27 @@ import StageChangeInfoVoting from "../components/stage_change_info_voting"
 import StageChangeInfoIdeaGeneration from "../components/stage_change_info_idea_generation"
 import StageChangeInfoClosed from "../components/stage_change_info_closed"
 import StageChangeInfoActionItems from "../components/stage_change_info_action_items"
+import StageChangeInfoPrimeDirective from "../components/stage_change_info_prime_directive"
 import STAGES from "./stages"
 
-const { PRIME_DIRECTIVE, IDEA_GENERATION, VOTING, ACTION_ITEMS, CLOSED } = STAGES
+const { LOBBY, PRIME_DIRECTIVE, IDEA_GENERATION, VOTING, ACTION_ITEMS, CLOSED } = STAGES
 
 export default {
-  [PRIME_DIRECTIVE]: {
+  [LOBBY]: {
     alert: null,
     confirmationMessage: "Has your entire party arrived?",
+    nextStage: PRIME_DIRECTIVE,
+    progressionButton: {
+      copy: "Begin Retro",
+      iconClass: "arrow right",
+    },
+  },
+  [PRIME_DIRECTIVE]: {
+    alert: {
+      headerText: "Stage Change: The Prime Directive!",
+      BodyComponent: StageChangeInfoPrimeDirective,
+    },
+    confirmationMessage: "Is everyone ready to begin?",
     nextStage: IDEA_GENERATION,
     progressionButton: {
       copy: "Proceed to Idea Generation",

--- a/web/static/js/configs/stages.js
+++ b/web/static/js/configs/stages.js
@@ -1,4 +1,5 @@
 export default {
+  LOBBY: "lobby",
   PRIME_DIRECTIVE: "prime-directive",
   IDEA_GENERATION: "idea-generation",
   VOTING: "voting",

--- a/web/static/js/prop_types.js
+++ b/web/static/js/prop_types.js
@@ -5,7 +5,7 @@ import PropTypes from "prop-types"
 
 import STAGES from "../js/configs/stages"
 
-const { PRIME_DIRECTIVE, IDEA_GENERATION, VOTING, ACTION_ITEMS, CLOSED } = STAGES
+const { LOBBY, PRIME_DIRECTIVE, IDEA_GENERATION, VOTING, ACTION_ITEMS, CLOSED } = STAGES
 
 export const alert = PropTypes.object
 
@@ -18,7 +18,7 @@ export const user = PropTypes.shape({
   is_facilitator: PropTypes.boolean,
 })
 
-export const users = PropTypes.arrayOf(PropTypes.object)
+export const users = PropTypes.arrayOf(user)
 
 export const retroChannel = PropTypes.shape({
   on: PropTypes.func,
@@ -33,6 +33,7 @@ export const idea = PropTypes.shape({
 })
 
 export const stage = PropTypes.oneOf([
+  LOBBY,
   PRIME_DIRECTIVE,
   IDEA_GENERATION,
   VOTING,


### PR DESCRIPTION
__Description of Change(s) Introduced:__ 
Retros now begin with a Lobby stage, which gives one set of instructions for the facilitator and a separate set for the participants.

__Description of Testing Applied:__
- Unit tests for LobbyStage component

__Relevant Screenshots/GIFs:__
_Facilitator_:
![facilitator](https://user-images.githubusercontent.com/2918454/34633261-1d07585e-f249-11e7-8a64-0205d02cae9c.png)
_Participant_:
![participant](https://user-images.githubusercontent.com/2918454/34633277-3403f4e0-f249-11e7-9d33-612911045d8c.png)

__Relevant github Issue:__ 
- #298 
