### PR TITLE
Restrict inputted and edited idea to 255 characters to match database

### DIFF
--- a/test/components/idea_edit_form_test.js
+++ b/test/components/idea_edit_form_test.js
@@ -23,6 +23,17 @@ describe("<IdeaEditForm />", () => {
       const textAreaValue = wrapper.find("textarea").props().value
       expect(textAreaValue).to.equal("redundant tests")
     })
+
+    context("the textarea field for an idea", () => {
+      it("contains the maxLength property with a limit of 255 characters", () => {
+        const retroChannel = { on: () => { } }
+        const wrapper = shallow(
+          <IdeaEditForm {...defaultProps} retroChannel={retroChannel} />
+        )
+        const textarea = wrapper.find("textarea")
+        expect(textarea.props().maxLength).to.equal("255")
+      })
+    })
   })
 
   describe("on change of the textarea", () => {

--- a/test/components/idea_submission_form_test.js
+++ b/test/components/idea_submission_form_test.js
@@ -20,6 +20,23 @@ describe("IdeaSubmissionForm component", () => {
     { id: 2, name: "Betty White" },
     { id: 3, name: "Bill Smith" },
   ]
+  describe("the input field for an idea", () => {
+    it("contains the maxLength property with a limit of 255 characters", () => {
+      const retroChannel = { on: () => { } }
+
+      wrapper = mountWithConnectedSubcomponents(
+        <IdeaSubmissionForm
+          currentUser={stubUser}
+          retroChannel={retroChannel}
+          stage={IDEA_GENERATION}
+          users={users}
+        />
+      )
+
+      const ideaInput = wrapper.find("input[name='idea']")
+      expect(ideaInput.props().maxLength).to.equal("255")
+    })
+  })
 
   describe("on submit", () => {
     describe("when in the IDEA_GENERATION stage", () => {

--- a/web/static/js/components/idea_edit_form.jsx
+++ b/web/static/js/components/idea_edit_form.jsx
@@ -70,6 +70,7 @@ class IdeaEditForm extends Component {
             rows="2"
             value={this.state.ideaBody}
             onChange={this.onChangeIdeaBody}
+            maxLength="255"
           />
         </div>
         <div className="ui buttons">

--- a/web/static/js/components/idea_submission_form.jsx
+++ b/web/static/js/components/idea_submission_form.jsx
@@ -135,6 +135,7 @@ export class IdeaSubmissionForm extends Component {
                 value={this.state.body}
                 onChange={this.handleIdeaChange}
                 placeholder={`Ex. ${PLACEHOLDER_TEXTS[this.state.category]}`}
+                maxLength="255"
               />
               <button type="submit" disabled={disabled} className="ui teal button">Submit</button>
             </div>


### PR DESCRIPTION
__Description of Change(s) Introduced:__  The user is now limited to input or edit an idea of up to 255 characters in order for an idea to correctly persist in the database.

__Description of Testing Applied:__  Tests were updated accordingly.

__Relevant github Issue:__ 

- [issue (318)](https://github.com/stride-nyc/remote_retro/issues/318)
