### PR TITLE
Serve local images from priv/assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "redux": "^3.6.0",
     "semantic-ui-css": "2.2.10",
     "sinon": "^1.17.7",
-    "webpack": "^3.8.1"
+    "webpack": "^3.8.1",
+    "write-file-webpack-plugin": "^4.2.0"
   },
   "devDependencies": {
     "babel-core": "^6.17.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,7 @@ const path = require("path")
 const webpack = require("webpack")
 const ExtractTextPlugin = require("extract-text-webpack-plugin")
 const CopyWebpackPlugin = require("copy-webpack-plugin")
+const WriteFileWebpackPlugin = require("write-file-webpack-plugin")
 const WebpackNotifierPlugin = require("webpack-notifier")
 
 process.noDeprecation = true
@@ -88,5 +89,6 @@ module.exports = {
     new webpack.HotModuleReplacementPlugin(),
     new ExtractTextPlugin({ filename: "css/app.css" }),
     new CopyWebpackPlugin([{ from: "./web/static/assets" }]),
+    new WriteFileWebpackPlugin([{ from: "./web/static/assets" }]),
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2569,6 +2569,10 @@ filename-regex@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
 
+filesize@^3.2.1:
+  version "3.5.11"
+  resolved "https://registry.yarnpkg.com/filesize/-/filesize-3.5.11.tgz#1919326749433bb3cf77368bd158caabcc19e9ee"
+
 fill-range@^2.1.0:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-2.2.3.tgz#50b77dfd7e469bc7492470963699fe7a8485a723"
@@ -3702,7 +3706,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@^4.0.0, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1:
+lodash@^4.0.0, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.5.1, lodash@^4.6.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -3918,6 +3922,10 @@ mock-css-modules@^1.0.0:
   resolved "https://registry.yarnpkg.com/mock-css-modules/-/mock-css-modules-1.0.0.tgz#8a5c7366cb62a0ef36e5e6db2ab3affd0fac36bd"
   dependencies:
     harmony-reflect "~1.4.2"
+
+moment@^2.11.2:
+  version "2.20.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.20.1.tgz#d6eb1a46cbcc14a2b2f9434112c1ff8907f313fd"
 
 ms@2.0.0:
   version "2.0.0"
@@ -6212,6 +6220,17 @@ wrap-ansi@^2.0.0:
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+
+write-file-webpack-plugin@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/write-file-webpack-plugin/-/write-file-webpack-plugin-4.2.0.tgz#7bd18547eaa0ea0b23992fb1e0322e5431d339ef"
+  dependencies:
+    chalk "^1.1.1"
+    debug "^2.6.8"
+    filesize "^3.2.1"
+    lodash "^4.5.1"
+    mkdirp "^0.5.1"
+    moment "^2.11.2"
 
 write@^0.2.1:
   version "0.2.1"


### PR DESCRIPTION
If you use `copy-webpack-plugin` from `webpack-dev-server`, "copied" files will be served from `OUTPUT_PUBLIC_PATH`, as defined in the webpack's config. We need the files written disk because Phoenix is serving the assets (not webpack). So this PR adds `write-file-webpack-plugin`, which writes to disk. This plugin [has no effect](https://github.com/gajus/write-file-webpack-plugin) when `webpack` is used instead of `webpack-dev-server`, so I think we're all good if this config file is re-used.

See: [copy-webpack-plugin](https://github.com/webpack-contrib/copy-webpack-plugin#faq) for docs.

__Description of Change(s) Introduced:__ 

Start using `write-file-webpack-plugin` in `webpack.config.js`.

__Dependencies Introduced or Upgraded:__ (if applicable)

- write-file-webpack-plugin - ^4.2.0

__Description of Testing Applied:__ (if applicable)

None

__Relevant Screenshots/GIFs:__ (if applicable)

Broken:
![Broken local images](https://api.monosnap.com/rpc/file/download?id=aTIdhALOzWrZhjaSkKyUH0jj5o1Fue)

Fixed:
![Fixed local images](https://api.monosnap.com/rpc/file/download?id=H29oUv4fHnEo2jvKEAHChvMYP9IDQE)
