### PR TITLE
Workflow: allow CircleCI to review pull requests from forked repos

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -40,7 +40,9 @@ test:
     - npm run test
     - mix test --exclude feature_test
     - mix test --only feature_test
-    - mix coveralls.circle --include feature_test
+    - if [ "$COVERALLS_REPO_TOKEN" != "" ]; then
+        mix coveralls.circle --include feature_test;
+      fi
 deployment:
   prod:
     branch: master


### PR DESCRIPTION
  - coveralls submissions on builds triggered by forked repos would cause barf coveralls to barf, breaking the build
  - the workaround is to only submit to coveralls in cases where the repo in question has a coveralls token.

__Description of Change(s) Introduced:__ 

__Dependencies Introduced or Upgraded:__ (if applicable)

- (Dependency) - (current version number)

__Description of Testing Applied:__ (if applicable)

__Relevant Screenshots/GIFs:__ (if applicable)

![Image Alt Text](image_url)

__Relevant github Issue:__ (if applicable)

- [issue (number)](issue_url)
