### PR TITLE
Display 'required' asterisk next to the 'Assignee' and 'Category' labels

### DIFF
--- a/test/components/select_dropdown_test.js
+++ b/test/components/select_dropdown_test.js
@@ -9,22 +9,22 @@ describe("SelectDropdown component", () => {
     value: "value",
     onChange() {},
     selectOptions: [],
+    isRequired: false,
   }
   let wrapper
 
-  context("when the stage is 'action-items'", () => {
-    it("renders with a 'required' class for the 'Assignee' label", () => {
-      const props = Object.assign(defaultProps, { labelName: "assignee" })
-      wrapper = shallow(<SelectDropdown {...props} />)
-      expect(wrapper.find(".required")).to.have.length(1)
+  context("when the isRequired prop is false", () => {
+    it("does not render with a 'required' class for the 'Category' label", () => {
+      wrapper = shallow(<SelectDropdown {...defaultProps} />)
+      expect(wrapper.find(".required")).to.have.length(0)
     })
   })
 
-  context("when the stage is 'idea-generation'", () => {
-    it("does not render with a 'required' class for the 'Category' label", () => {
-      const props = Object.assign(defaultProps, { labelName: "category" })
+  context("when the isRequired prop is true", () => {
+    it("renders with a 'required' class for the 'Assignee' label", () => {
+      const props = Object.assign(defaultProps, { isRequired: true })
       wrapper = shallow(<SelectDropdown {...props} />)
-      expect(wrapper.find(".required")).to.have.length(0)
+      expect(wrapper.find(".required")).to.have.length(1)
     })
   })
 

--- a/test/components/select_dropdown_test.js
+++ b/test/components/select_dropdown_test.js
@@ -12,6 +12,11 @@ describe("SelectDropdown component", () => {
   }
   let wrapper
 
+  it("renders with a 'required' class", () => {
+    wrapper = shallow(<SelectDropdown {...defaultProps} />)
+    expect(wrapper.find(".required")).to.have.length(1)
+  })
+
   context("when pointerText is not provided as a prop", () => {
     it("does not render the pointing label", () => {
       wrapper = shallow(<SelectDropdown {...defaultProps} />)

--- a/test/components/select_dropdown_test.js
+++ b/test/components/select_dropdown_test.js
@@ -12,9 +12,20 @@ describe("SelectDropdown component", () => {
   }
   let wrapper
 
-  it("renders with a 'required' class", () => {
-    wrapper = shallow(<SelectDropdown {...defaultProps} />)
-    expect(wrapper.find(".required")).to.have.length(1)
+  context("when the stage is 'action-items'", () => {
+    it("renders with a 'required' class for the 'Assignee' label", () => {
+      const props = Object.assign(defaultProps, { labelName: "assignee" })
+      wrapper = shallow(<SelectDropdown {...props} />)
+      expect(wrapper.find(".required")).to.have.length(1)
+    })
+  })
+
+  context("when the stage is 'idea-generation'", () => {
+    it("does not render with a 'required' class for the 'Category' label", () => {
+      const props = Object.assign(defaultProps, { labelName: "category" })
+      wrapper = shallow(<SelectDropdown {...props} />)
+      expect(wrapper.find(".required")).to.have.length(0)
+    })
   })
 
   context("when pointerText is not provided as a prop", () => {

--- a/web/static/js/components/css_modules/idea_submission_form.css
+++ b/web/static/js/components/css_modules/idea_submission_form.css
@@ -22,3 +22,7 @@
   top: -3em;
   left: 33%;
 }
+
+#required:after {
+  display: inline;
+}

--- a/web/static/js/components/idea_edit_form.jsx
+++ b/web/static/js/components/idea_edit_form.jsx
@@ -78,6 +78,7 @@ class IdeaEditForm extends Component {
           onChange={this.onChangeIdeaCategory}
           selectOptions={categoryOptions}
           showLabel={false}
+          isRequired={false}
         />}
         {stage === ACTION_ITEMS && <SelectDropdown
           labelName="editable_assignee"
@@ -85,6 +86,7 @@ class IdeaEditForm extends Component {
           onChange={this.onChangeAssignee}
           selectOptions={assigneeOptions}
           showLabel={false}
+          isRequired={false}
         />}
         <div className="field">
           <textarea

--- a/web/static/js/components/idea_submission_form.jsx
+++ b/web/static/js/components/idea_submission_form.jsx
@@ -96,6 +96,7 @@ export class IdeaSubmissionForm extends Component {
         value: category,
         onChange: this.handleCategoryChange,
         selectOptions: defaultCategoryOptions,
+        isRequired: false,
       }
     } else if (stage === ACTION_ITEMS) {
       pointerText = !ideaEntryStarted ? "Create Action Items!" : ""
@@ -104,6 +105,7 @@ export class IdeaSubmissionForm extends Component {
         value: assigneeId || "",
         onChange: this.handleAssigneeChange,
         selectOptions: [defaultOption, ...assigneeOptions],
+        isRequired: true,
       }
     }
 

--- a/web/static/js/components/select_dropdown.jsx
+++ b/web/static/js/components/select_dropdown.jsx
@@ -6,7 +6,8 @@ import classNames from "classnames"
 import styles from "./css_modules/idea_submission_form.css"
 
 const SelectDropdown = ({ labelName, value, onChange, selectOptions, showLabel }) => {
-  const divClasses = showLabel ? `${styles.flex} five wide required inline field` : ""
+  const requiredAssignee = labelName === "assignee" ? "required" : ""
+  const divClasses = showLabel ? `${styles.flex} five wide ${requiredAssignee} inline field` : ""
   const selectClasses = classNames("ui dropdown", {
     [styles.select]: showLabel,
   })

--- a/web/static/js/components/select_dropdown.jsx
+++ b/web/static/js/components/select_dropdown.jsx
@@ -5,8 +5,8 @@ import classNames from "classnames"
 
 import styles from "./css_modules/idea_submission_form.css"
 
-const SelectDropdown = ({ labelName, value, onChange, selectOptions, showLabel }) => {
-  const requiredAssignee = labelName === "assignee" ? "required" : ""
+const SelectDropdown = ({ labelName, value, onChange, selectOptions, showLabel, isRequired }) => {
+  const requiredAssignee = isRequired ? "required" : ""
   const divClasses = showLabel ? `${styles.flex} five wide ${requiredAssignee} inline field` : ""
   const selectClasses = classNames("ui dropdown", {
     [styles.select]: showLabel,
@@ -40,6 +40,7 @@ SelectDropdown.propTypes = {
   selectOptions: PropTypes.arrayOf(PropTypes.object).isRequired,
   pointerText: PropTypes.string,
   showLabel: PropTypes.bool,
+  isRequired: PropTypes.bool.isRequired,
 }
 
 SelectDropdown.defaultProps = {

--- a/web/static/js/components/select_dropdown.jsx
+++ b/web/static/js/components/select_dropdown.jsx
@@ -6,12 +6,12 @@ import classNames from "classnames"
 import styles from "./css_modules/idea_submission_form.css"
 
 const SelectDropdown = ({ labelName, value, onChange, selectOptions, showLabel }) => {
-  const divClasses = showLabel ? `${styles.flex} five wide inline field` : ""
+  const divClasses = showLabel ? `${styles.flex} five wide required inline field` : ""
   const selectClasses = classNames("ui dropdown", {
     [styles.select]: showLabel,
   })
   const label = showLabel
-    ? (<label htmlFor={labelName}>{`${capitalize(labelName)}:`}</label>)
+    ? (<label id={styles.required} htmlFor={labelName}>{`${capitalize(labelName)}:`}</label>)
     : ""
   return (
     <div className={divClasses}>


### PR DESCRIPTION
__Description of Change(s) Introduced:__ 
This PR displays an asterisk next to the required form labels: 'Assignee' and 'Category'.

__Description of Testing Applied:__ front-end test has been updated accordingly

__Relevant Screenshots/GIFs:__ 
![image](https://user-images.githubusercontent.com/8727588/35244679-03c3615a-ff8f-11e7-90ce-17750d3e2dfd.png)

![image](https://user-images.githubusercontent.com/8727588/35244691-11bc35de-ff8f-11e7-9cbb-8bd02d93064e.png)

__Relevant github Issue:__ 

- [issue (368)](https://github.com/stride-nyc/remote_retro/issues/368)
