### PR TITLE
disable alert for facilitation transfer on closed stage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ web/static/js/dll/*
 
 npm-debug.log*
 .eslintcache
+browser_logs.log

--- a/test/components/user_list_item_test.js
+++ b/test/components/user_list_item_test.js
@@ -4,7 +4,7 @@ import { shallow, mount } from "enzyme"
 import { UserListItem } from "../../web/static/js/components/user_list_item"
 import STAGES from "../../web/static/js/configs/stages"
 
-const { IDEA_GENERATION, VOTING } = STAGES
+const { IDEA_GENERATION, VOTING, CLOSED } = STAGES
 
 const defaultUserAttrs = {
   given_name: "dylan",
@@ -43,6 +43,20 @@ describe("UserListItem", () => {
         <UserListItem {...defaultProps} user={facilitator} />
       )
       expect(wrapper.text()).to.match(/dylan \(facilitator\)/i)
+    })
+  })
+
+  describe("when the stage is 'closed", () => {
+    const facilitator = { ...defaultUserAttrs, is_facilitator: true }
+    it("does not label any new facilitators", () => {
+      const wrapper = mount(
+        <UserListItem
+          {...defaultProps}
+          user={facilitator}
+          stage={CLOSED}
+        />
+      )
+      expect(wrapper.text()).not.to.match(/dylan \(facilitator\)/i)
     })
   })
 

--- a/web/static/js/components/remote_retro.jsx
+++ b/web/static/js/components/remote_retro.jsx
@@ -8,6 +8,9 @@ import * as AppPropTypes from "../prop_types"
 import Room from "./room"
 import Alert from "./alert"
 import DoorChime from "./door_chime"
+import STAGES from "../configs/stages"
+
+const { CLOSED } = STAGES
 
 export function isNewFacilitator(prevCurrentUser, currentUser) {
   return ((prevCurrentUser.is_facilitator !== currentUser.is_facilitator)
@@ -26,7 +29,7 @@ export class RemoteRetro extends Component {
 
     if (prevProps.presences.length) {
       const prevCurrentUser = prevProps.currentUser
-      if (isNewFacilitator(prevCurrentUser, currentUser)) {
+      if (isNewFacilitator(prevCurrentUser, currentUser) && stage !== CLOSED) {
         actions.changeFacilitator(prevProps.facilitatorName)
       }
     }

--- a/web/static/js/components/user_list_item.jsx
+++ b/web/static/js/components/user_list_item.jsx
@@ -6,7 +6,7 @@ import styles from "./css_modules/user_list_item.css"
 import AnimatedEllipsis from "./animated_ellipsis"
 import STAGES from "../configs/stages"
 
-const { VOTING } = STAGES
+const { VOTING, CLOSED } = STAGES
 
 export const UserListItem = ({ user, votes, stage }) => {
   let givenName = user.given_name
@@ -14,7 +14,7 @@ export const UserListItem = ({ user, votes, stage }) => {
   const votesByUser = votes.filter(vote => vote.user_id === user.id).length
   const allVotesIn = votesByUser >= voteMax
 
-  if (user.is_facilitator) givenName += " (Facilitator)"
+  if (user.is_facilitator && stage !== CLOSED) givenName += " (Facilitator)"
 
   return (
     <li className={`item ${styles.wrapper}`}>


### PR DESCRIPTION
__Description of Change(s) Introduced:__ 
* Disable alert and label of (Facilitator) for facilitation transfer when retro is in stage=closed

__Relevant github Issue:__ 

- [issue (376)](https://github.com/stride-nyc/remote_retro/issues/376)
