### PR TITLE
Fix modal warning in console and tests

### DIFF
--- a/web/static/js/components/alert.jsx
+++ b/web/static/js/components/alert.jsx
@@ -8,12 +8,9 @@ import { actions as actionCreators } from "../redux"
 
 Modal.defaultStyles.content.zIndex = 2
 Modal.defaultStyles.overlay.zIndex = 2
+Modal.setAppElement("body")
 
 export class Alert extends Component {
-
-  componentWillMount() {
-    Modal.setAppElement("body")
-  }
 
   render() {
     if (!this.props.config) return null

--- a/web/static/js/components/alert.jsx
+++ b/web/static/js/components/alert.jsx
@@ -10,6 +10,11 @@ Modal.defaultStyles.content.zIndex = 2
 Modal.defaultStyles.overlay.zIndex = 2
 
 export class Alert extends Component {
+
+  componentWillMount() {
+    Modal.setAppElement("body")
+  }
+
   render() {
     if (!this.props.config) return null
 


### PR DESCRIPTION
__Description of changes introduced:__
The following warning is shown in both the console and the e2e test output: 

` react-modal: App element is not defined. Please use `Modal.setAppElement(el)` or set `appElement={el}`. This is needed so screen readers don't see main content when modal is opened. It is not recommended `

This fix will set the element before the render with `componentWillMont()`

A few references: 
https://github.com/reactjs/react-modal/issues/133
https://stackoverflow.com/questions/48269381/warning-react-modal-app-element-is-not-defined-please-use-modal-setappeleme
https://github.com/reactjs/react-modal/issues/576