### PR TITLE
Hide live edits for ideas authored by facilitator

### DIFF
--- a/test/components/idea_edit_form_test.js
+++ b/test/components/idea_edit_form_test.js
@@ -126,10 +126,31 @@ describe("<IdeaEditForm />", () => {
       })
 
       context("when the currentUser is the facilitator", () => {
-        it("pushes a `idea_live_edit` event to the retroChannel, passing current input value", () => {
-          expect(
-            retroChannel.push
-          ).calledWith("idea_live_edit", { id: idea.id, liveEditText: "some value" })
+        context("when ideas are *not* authored by the facilitator", () => {
+          it("pushes a `idea_live_edit` event to the retroChannel, passing current input value", () => {
+            expect(
+              retroChannel.push
+            ).calledWith("idea_live_edit", { id: idea.id, liveEditText: "some value" })
+          })
+        })
+
+        context("when ideas are authored by the facilitator", () => {
+          it("does not push a `idea_live_edit` event to the retroChannel", () => {
+            const testProps = {
+              ...defaultProps,
+              idea: { id: 1000, body: "do the thing", user_id: currentUser.id, assignee_id: 9 },
+            }
+            retroChannel = { on: () => {}, push: sinon.spy() }
+            wrapper = mountWithConnectedSubcomponents(
+              <IdeaEditForm {...testProps} retroChannel={retroChannel} />
+            )
+            textarea = wrapper.find("textarea")
+            textarea.simulate("change", { target: { name: "editable_idea", value: "some value" } })
+
+            expect(
+              retroChannel.push
+            ).not.called
+          })
         })
       })
 

--- a/test/features/retro_idea_realtime_update_test.exs
+++ b/test/features/retro_idea_realtime_update_test.exs
@@ -27,6 +27,7 @@ defmodule RetroIdeaRealtimeUpdateTest do
 
     @tag [
       idea: %Idea{category: "sad", body: "no linter"},
+      idea_author: :non_facilitator
     ]
     test "the immediate update of ideas as they are changed/saved", ~M{retro, session: facilitator_session} do
       participant_session = new_authenticated_browser_session()
@@ -71,20 +72,19 @@ defmodule RetroIdeaRealtimeUpdateTest do
   end
 
   describe "when an action item has been assigned to a particular user" do
-    setup [:persist_additional_users_for_retro, :persist_idea_for_retro]
+    setup [:persist_idea_for_retro]
 
     @tag [
       retro_stage: "action-items",
       idea: %Idea{body: "blurgh", category: "action-item"},
-      additional_users: [@test_user_two]
     ]
 
-    test "it can be re-assigned to a different user", ~M{retro, user, session: facilitator_session} do
+    test "it can be re-assigned to a different user", ~M{retro, facilitator, session: facilitator_session} do
       retro_path = "/retros/" <> retro.id
       facilitator_session = visit(facilitator_session, retro_path)
 
       action_items_list_text = facilitator_session |> find(Query.css(".action-item.column")) |> Element.text()
-      assert action_items_list_text =~ "blurgh (#{user.name})"
+      assert action_items_list_text =~ "blurgh (#{facilitator.name})"
 
       facilitator_session
       |> click(Query.css(".edit"))

--- a/test/support/integration_case.ex
+++ b/test/support/integration_case.ex
@@ -41,7 +41,10 @@ defmodule RemoteRetro.IntegrationCase do
     retro =
       case tags[:retro_stage] do
         nil -> tags[:retro]
-        _ -> Repo.insert!(%Retro{stage: tags[:retro_stage], facilitator_id: user.id})
+        _ ->
+          tags[:retro]
+          |> Retro.changeset(%{stage: tags[:retro_stage]})
+          |> Repo.update!
       end
 
     session = new_authenticated_browser_session(metadata)

--- a/web/static/js/components/idea_edit_form.jsx
+++ b/web/static/js/components/idea_edit_form.jsx
@@ -24,7 +24,7 @@ class IdeaEditForm extends Component {
     let newIdeaBodyError
     const { retroChannel, idea, currentUser } = this.props
 
-    if (currentUser.is_facilitator) {
+    if (currentUser.is_facilitator && currentUser.id !== idea.user_id) {
       retroChannel.push("idea_live_edit", { id: idea.id, liveEditText: target.value })
     }
 


### PR DESCRIPTION
__Description of Change(s) Introduced:__ 

- Update IdeaEditForm to hide live edits for ideas authored by facilitator
- Reinstate timer.sleep call when instantiating chrome sessions
- Update user_retro_case to add two users: facilitator and non_facilitator
- Update persist_idea_for_retro to allow for second user as idea author

__Relevant github Issue:__ (if applicable)

- [issue 475](https://github.com/stride-nyc/remote_retro/issues/475)
