### PR TITLE
Favor `asdf` over `nvm` for version management of NodeJS

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
 erlang 20.3.8.8
 elixir 1.5.3
+nodejs 8.7.0

--- a/README.md
+++ b/README.md
@@ -76,22 +76,17 @@ psql -h localhost
   - Create the "remote_retro_test" database and migrate via `MIX_ENV=test mix ecto.create && mix ecto.migrate`
 
 #### Node Dependencies
+We will use `asdf-nodejs`.
+It has a couple other dependencies, see [their README](https://github.com/asdf-vm/asdf-nodejs) for specifics for your system.
 
-Install nvm (node version manager):
-
+Install `nodejs` using `asdf` after following the directions from their README.
 ```
-curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.1/install.sh | bash
-```
-__Note:__ additional nvm installation notes found at [the nvm repo](https://github.com/creationix/nvm#install-script).
-
-Install the latest node via nvm:
-```
-nvm install 8.7
+asdf plugin-add nodejs https://github.com/asdf-vm/asdf-nodejs.git
 ```
 
-Ensure the latest node is your default node version in new shells:
+Install the project's version of nodejs
 ```
-nvm alias default 8.7
+asdf install nodejs $(cat .tool-versions | grep nodejs | awk '{print $2}')
 ```
 
 Install Global NPM Packages


### PR DESCRIPTION
__Description of Change(s) Introduced:__ 
`asdf` is an agnostic version management tool.
It would make sense to move to using it over `nvm` since that is already introduced for Elixir.

__Dependencies Introduced or Upgraded:__ (if applicable)
`asdf-nodejs` - added
`nvm` - removed

__Description of Testing Applied:__ (if applicable)
Ran on my system with exact copy/paste, installed the things, checked that it worked.

__Relevant Screenshots/GIFs:__ (if applicable)
n/a

__Relevant github Issue:__ (if applicable)
n/a