### PR TITLE
Validate presence of assignee_id on Idea when an action-item

### DIFF
--- a/lib/remote_retro_web/models/idea.ex
+++ b/lib/remote_retro_web/models/idea.ex
@@ -28,5 +28,15 @@ defmodule RemoteRetro.Idea do
     struct
     |> cast(params, @mutable_fields)
     |> validate_required(@required_fields)
+    |> validate_assignee_required_for_action_items()
+  end
+
+  def validate_assignee_required_for_action_items(changeset) do
+    category = get_field(changeset, :category)
+
+    case category do
+      "action-item" -> validate_required(changeset, :assignee_id)
+      _ -> changeset
+    end
   end
 end

--- a/test/models/idea_test.exs
+++ b/test/models/idea_test.exs
@@ -33,7 +33,7 @@ defmodule RemoteRetro.IdeaTest do
     end
 
     test "assignee_id NOT required when idea category NOT action-item" do
-      changeset = Idea.changeset(%Idea{category: "happy", assignee_id: 1})
+      changeset = Idea.changeset(%Idea{category: "happy", assignee_id: nil})
 
       refute Keyword.has_key?(changeset.errors, :assignee_id)
     end

--- a/test/models/idea_test.exs
+++ b/test/models/idea_test.exs
@@ -17,6 +17,28 @@ defmodule RemoteRetro.IdeaTest do
     assert user_id_error == "can't be blank"
   end
 
+  describe "validating assignee_id presence" do
+    test "assignee_id required when idea is action-item" do
+      changeset = Idea.changeset(%Idea{category: "action-item", assignee_id: nil})
+
+      {asignee_id_error, _} = Keyword.fetch!(changeset.errors, :assignee_id)
+
+      assert asignee_id_error == "can't be blank"
+    end
+
+    test "assignee_id and category action-item do not trigger error" do
+      changeset = Idea.changeset(%Idea{category: "action-item", assignee_id: 1})
+
+      refute Keyword.has_key?(changeset.errors, :assignee_id)
+    end
+
+    test "assignee_id NOT required when idea category NOT action-item" do
+      changeset = Idea.changeset(%Idea{category: "happy", assignee_id: 1})
+
+      refute Keyword.has_key?(changeset.errors, :assignee_id)
+    end
+  end
+
   describe "JSON encoding of the model struct" do
     test "is enabled" do
       idea = %Idea{category: "sad", body: "flaky e2e test", id: 5}


### PR DESCRIPTION
__Description of Change(s) Introduced:__ 
When an `Idea` is created or modified, require that an `assignee_id` is present if the `Idea` is an `action-item`.

__Description of Testing Applied:__
3 unit tests for new validation on `Idea` model.

__Relevant github Issue:__ (if applicable)

- issue #413
