### PR TITLE
Make user lobby guests wrap around

### DIFF
--- a/test/components/user_list_test.js
+++ b/test/components/user_list_test.js
@@ -29,13 +29,13 @@ describe("passed an array of users", () => {
   }]
 
   it("is renders a list item for each user presence", () => {
-    const wrapper = shallow(<UserList presences={presences} />)
+    const wrapper = shallow(<UserList wrap={false} presences={presences} />)
     expect(wrapper.find(UserListItem)).to.have.length(3)
   })
 
   it("sorts the presences such that the facilitator is first, followed by users by arrival ascending", () => {
     const wrapper = mountWithConnectedSubcomponents(
-      <UserList presences={presences} />
+      <UserList wrap={false} presences={presences} />
     )
     expect(wrapper.text()).to.match(/sarah.*zander.*treezy/i)
   })
@@ -48,7 +48,7 @@ describe("passed an array of users", () => {
 
     it("sorts the users solely by their arrival ascending ", () => {
       const wrapper = mountWithConnectedSubcomponents(
-        <UserList presences={nonFacilitatorPresences} />
+        <UserList wrap={false} presences={nonFacilitatorPresences} />
       )
 
       expect(wrapper.find(UserListItem)).to.have.length(3)
@@ -56,9 +56,16 @@ describe("passed an array of users", () => {
     })
   })
 
+  describe("when wrap is true", () => {
+    it("displays modified user list", () => {
+      const wrapper = shallow(<UserList wrap presences={presences} />)
+      expect(wrapper.find("ul").hasClass("wrap")).to.equal(true)
+    })
+  })
+
   describe("when the presences list is empty", () => {
     it("executes a null render", () => {
-      const wrapper = shallow(<UserList presences={[]} />)
+      const wrapper = shallow(<UserList wrap={false} presences={[]} />)
       expect(wrapper.html()).to.equal(null)
     })
   })

--- a/web/static/js/components/centered_text_stage_wrapper.jsx
+++ b/web/static/js/components/centered_text_stage_wrapper.jsx
@@ -3,7 +3,6 @@ import PropTypes from "prop-types"
 
 import StageProgressionButton from "./stage_progression_button"
 import UserList from "./user_list"
-
 import styles from "./css_modules/centered_text_stage_wrapper.css"
 
 const CenteredTextStageWrapper = props => {
@@ -19,7 +18,7 @@ const CenteredTextStageWrapper = props => {
       </div>
       <div className="row">
         <h2 className="ui medium dividing header">Current Users</h2>
-        <UserList />
+        <UserList wrap />
       </div>
       <div className="row">
         <StageProgressionButton

--- a/web/static/js/components/css_modules/user_list.css
+++ b/web/static/js/components/css_modules/user_list.css
@@ -1,14 +1,6 @@
 :global(.basic.segment).index {
   :global(.horizontal.list) {
     margin-left: 0;
-    display: inline-grid;
-    overflow-x: scroll;
-    grid-template-rows: 1fr 1fr 1fr;
-    grid-auto-flow: column;
-
-    :global(.item), :global(.item:first-child){
-      margin: 0rem 1rem;
-    }
   }
   margin-top: 0;
   margin-bottom: 0;
@@ -20,3 +12,17 @@
   white-space: nowrap;
   overflow-x: scroll;
 }
+
+:global(.basic.segment).index {
+  :global(.wrap) {
+    display: inline-grid;
+    overflow-x: scroll;
+    grid-template-rows: 1fr 1fr 1fr;
+    grid-auto-flow: column;
+
+    :global(.item), :global(.item:first-child){
+      margin: 0rem 1rem;
+    }
+  }
+}
+

--- a/web/static/js/components/css_modules/user_list.css
+++ b/web/static/js/components/css_modules/user_list.css
@@ -1,6 +1,14 @@
 :global(.basic.segment).index {
   :global(.horizontal.list) {
     margin-left: 0;
+    display: inline-grid;
+    overflow-x: scroll;
+    grid-template-rows: 1fr 1fr 1fr;
+    grid-auto-flow: column;
+
+    :global(.item), :global(.item:first-child){
+      margin: 0rem 1rem;
+    }
   }
   margin-top: 0;
   margin-bottom: 0;

--- a/web/static/js/components/css_modules/user_list.css
+++ b/web/static/js/components/css_modules/user_list.css
@@ -15,10 +15,11 @@
 
 :global(.basic.segment).index {
   :global(.wrap) {
-    display: inline-grid;
+    max-width: 28rem;
+    max-height: 24rem;
+    display: inline-block;
+    white-space: initial;
     overflow-x: scroll;
-    grid-template-rows: 1fr 1fr 1fr;
-    grid-auto-flow: column;
 
     :global(.item), :global(.item:first-child){
       margin: 0rem 1rem;

--- a/web/static/js/components/idea_generation_stage.jsx
+++ b/web/static/js/components/idea_generation_stage.jsx
@@ -10,7 +10,7 @@ import { CATEGORIES } from "../configs/retro_configs"
 const IdeaGenerationStage = props => (
   <div className={styles.wrapper}>
     <IdeaBoard {...props} categories={CATEGORIES} />
-    <UserList />
+    <UserList wrap={false} />
     <LowerThird {...props} />
   </div>
 )

--- a/web/static/js/components/user_list.jsx
+++ b/web/static/js/components/user_list.jsx
@@ -1,12 +1,15 @@
 import React from "react"
 import { connect } from "react-redux"
+import classNames from "classnames"
 
 import UserListItem from "./user_list_item"
+
 import * as AppPropTypes from "../prop_types"
+import PropTypes from "prop-types"
 import styles from "./css_modules/user_list.css"
 import { selectors } from "../redux/users_by_id"
 
-export const UserList = ({ presences }) => {
+export const UserList = ({ presences, wrap }) => {
   if (presences.length === 0) { return null }
 
   const sortedByArrival = presences.sort((a, b) => a.online_at - b.online_at)
@@ -27,9 +30,11 @@ export const UserList = ({ presences }) => {
     return <UserListItem key={presence.token} user={presence} />
   })
 
+  const userListClasses = classNames("ui tiny horizontal list", { wrap })
+
   return (
     <section className={`${styles.index} ui center aligned basic segment`}>
-      <ul id="user-list" className="ui tiny horizontal list">
+      <ul id="user-list" className={userListClasses}>
         {listItems}
       </ul>
     </section>
@@ -38,6 +43,7 @@ export const UserList = ({ presences }) => {
 
 UserList.propTypes = {
   presences: AppPropTypes.presences.isRequired,
+  wrap: PropTypes.bool.isRequired,
 }
 
 const mapStateToProps = state => {

--- a/web/static/js/components/user_list.jsx
+++ b/web/static/js/components/user_list.jsx
@@ -1,11 +1,11 @@
 import React from "react"
 import { connect } from "react-redux"
 import classNames from "classnames"
+import PropTypes from "prop-types"
 
 import UserListItem from "./user_list_item"
 
 import * as AppPropTypes from "../prop_types"
-import PropTypes from "prop-types"
 import styles from "./css_modules/user_list.css"
 import { selectors } from "../redux/users_by_id"
 


### PR DESCRIPTION
__Description of Change(s) Introduced:__ 

Adds some CSS to allow lobby guests to wrap to multiple rows in the lobby and prime directive stages

`UserList` now takes a `wrap` property that toggles which form of the `UserList` you receive

__Relevant Screenshots/GIFs:__ (if applicable)

![image](https://d3a1eqpdtt5fg4.cloudfront.net/items/0G072J371c1q3t0A3I1o/Screen%20Shot%202019-03-18%20at%202.58.38%20PM.png)


__Relevant github Issue:__ (if applicable)

https://github.com/stride-nyc/remote_retro/issues/453