### PR TITLE
Allow users to access stage breakdowns for help

### DIFF
--- a/lib/remote_retro_web/templates/layout/app.html.eex
+++ b/lib/remote_retro_web/templates/layout/app.html.eex
@@ -72,7 +72,8 @@
           </div>
         </a>
         <div class="ui right floated header right-branded-header grid">
-          <a href="http://stridenyc.com?utm_campaign=RemoteRetro&utm_source=Micro%20Website&utm_medium=remoteretro" target="_blank" class="ui grid computer tablet only">
+          <div class="help-icon" id="stage-help-icon"></div>
+          <a href="http://stridenyc.com?utm_campaign=RemoteRetro&utm_source=Micro%20Website&utm_medium=remoteretro" target="_blank" class="grid computer tablet only">
             <div>
               <div class="middle aligned content logo-text">Built by</div>
               <div class="ui tiny image"><img src="<%= Routes.static_path(@conn, "/images/stride_logo.png") %>" alt="Stride" /></div>

--- a/test/components/remote_retro_test.js
+++ b/test/components/remote_retro_test.js
@@ -18,6 +18,7 @@ describe("RemoteRetro component", () => {
     ideas: [],
     stage: IDEA_GENERATION,
     facilitatorName: "Daniel Handpan",
+    retro: {},
   }
 
   context("when the component mounts", () => {

--- a/test/components/remote_retro_test.js
+++ b/test/components/remote_retro_test.js
@@ -18,7 +18,7 @@ describe("RemoteRetro component", () => {
     ideas: [],
     stage: IDEA_GENERATION,
     facilitatorName: "Daniel Handpan",
-    retro: {},
+    retro: { stage: IDEA_GENERATION },
   }
 
   context("when the component mounts", () => {

--- a/test/components/stage_help_test.js
+++ b/test/components/stage_help_test.js
@@ -3,6 +3,7 @@ import sinon from "sinon"
 import { shallow } from "enzyme"
 
 import { StageHelp } from "../../web/static/js/components/stage_help"
+import STAGES from "../../web/static/js/configs/stages"
 
 describe("<StageHelp />", () => {
   let wrapper
@@ -25,7 +26,7 @@ describe("<StageHelp />", () => {
 
   describe("when it is a stage with help to show", () => {
     beforeEach(() => {
-      retro = { stage: "idea-generation" }
+      retro = { stage: STAGES.IDEA_GENERATION }
       const newProps = { ...defaultProps, retro }
       wrapper = shallow(<StageHelp {...newProps} />)
     })
@@ -44,7 +45,7 @@ describe("<StageHelp />", () => {
 
   describe("when it is a stage with no help to show", () => {
     beforeEach(() => {
-      const retro = { stage: null }
+      const retro = { stage: STAGES.LOBBY }
       const newProps = { ...defaultProps, retro }
       wrapper = shallow(<StageHelp {...newProps} />)
     })

--- a/test/components/stage_help_test.js
+++ b/test/components/stage_help_test.js
@@ -1,0 +1,56 @@
+import React from "react"
+import sinon from "sinon"
+import { shallow } from "enzyme"
+
+import { StageHelp } from "../../web/static/js/components/stage_help"
+
+describe("<StageHelp />", () => {
+  let wrapper
+  let retro
+
+  // Setup JSDom so that react can inject a portal
+  const iconRoot = global.document.createElement("div")
+  iconRoot.setAttribute("id", "stage-help-icon")
+  const body = global.document.querySelector("body")
+  body.appendChild(iconRoot)
+
+  const actions = {
+    showStageHelp: sinon.spy(),
+  }
+
+  const defaultProps = {
+    actions,
+    retro: {},
+  }
+
+  describe("when it is a stage with help to show", () => {
+    beforeEach(() => {
+      retro = { stage: "idea-generation" }
+      const newProps = { ...defaultProps, retro }
+      wrapper = shallow(<StageHelp {...newProps} />)
+    })
+
+    it("renders the question mark icon", () => {
+      expect(wrapper.find("i.question").exists()).to.equal(true)
+    })
+
+    describe("when clicking the icon for help", () => {
+      it("dispatches showStageHelp with the retro object", () => {
+        wrapper.find("i.question").simulate("click")
+        expect(actions.showStageHelp).to.have.been.calledWith(retro)
+      })
+    })
+  })
+
+  describe("when it is a stage with no help to show", () => {
+    beforeEach(() => {
+      const retro = { stage: null }
+      const newProps = { ...defaultProps, retro }
+      wrapper = shallow(<StageHelp {...newProps} />)
+    })
+
+    it("does NOT render the question mark icon", () => {
+      expect(wrapper.find("i.question").exists()).to.equal(false)
+    })
+  })
+})

--- a/test/redux/alert_test.js
+++ b/test/redux/alert_test.js
@@ -59,6 +59,39 @@ describe("alert", () => {
       })
     })
 
+    describe("when the action is SHOW_STAGE_HELP", () => {
+      const initialState = { headerText: "Warning!", bodyText: "You're being watched." }
+      const stageConfigs = {
+        daybreak: {
+          help: {
+            headerText: "I need help!",
+            bodyText: "Tell me what to do",
+          },
+        },
+        stageLackingHelpConfig: {},
+      }
+
+      deepFreeze(initialState)
+      deepFreeze(stageConfigs)
+
+      describe("when the given stage has a help in the given configuration map", () => {
+        const action = {
+          type: "SHOW_STAGE_HELP",
+          retro: {
+            stage: "daybreak",
+          },
+          stageConfigs,
+        }
+
+        it("returns the help for the given stage", () => {
+          expect(reducer(initialState, action)).to.deep.equal({
+            headerText: "I need help!",
+            bodyText: "Tell me what to do",
+          })
+        })
+      })
+    })
+
     describe("when the action is CLEAR_ALERT", () => {
       const action = { type: "CLEAR_ALERT" }
 

--- a/test/redux/alert_test.js
+++ b/test/redux/alert_test.js
@@ -68,6 +68,9 @@ describe("alert", () => {
             bodyText: "Tell me what to do",
           },
         },
+        nightfall: {
+          no_help: {},
+        },
         stageLackingHelpConfig: {},
       }
 
@@ -88,6 +91,20 @@ describe("alert", () => {
             headerText: "I need help!",
             bodyText: "Tell me what to do",
           })
+        })
+      })
+
+      describe("when the given stage does NOT have a help in the given configuration map", () => {
+        const action = {
+          type: "SHOW_STAGE_HELP",
+          retro: {
+            stage: "nightfall",
+          },
+          stageConfigs,
+        }
+
+        it("returns the help for the given stage", () => {
+          expect(reducer(initialState, action)).to.deep.equal(null)
         })
       })
     })

--- a/test/redux/alert_test.js
+++ b/test/redux/alert_test.js
@@ -103,7 +103,7 @@ describe("alert", () => {
           stageConfigs,
         }
 
-        it("returns the help for the given stage", () => {
+        it("returns a null for the given stage", () => {
           expect(reducer(initialState, action)).to.deep.equal(null)
         })
       })

--- a/web/static/css/app.css
+++ b/web/static/css/app.css
@@ -208,6 +208,11 @@
       padding-top: 0.15rem;
     }
 
+    .help-icon {
+      padding: 0.1rem 0rem 0rem 0rem;
+      cursor: pointer;
+    }
+
     :global(.ui.tiny.image) {
       /* necessary for IE 10 & 11, as height: auto applies no restriction to height of svgs,
        * and height: 100% only applies if the element's container has an explicit height

--- a/web/static/js/components/remote_retro.jsx
+++ b/web/static/js/components/remote_retro.jsx
@@ -38,6 +38,7 @@ export class RemoteRetro extends Component {
       currentUser,
       facilitatorName,
       isTabletOrAbove,
+      retro,
     } = this.props
 
     return (
@@ -54,7 +55,7 @@ export class RemoteRetro extends Component {
         <Alert config={alert} />
         <Error config={error} />
         <DoorChime presences={presences} />
-        <StageHelp />
+        <StageHelp retro={retro} />
       </div>
     )
   }
@@ -71,6 +72,7 @@ RemoteRetro.propTypes = {
   currentUser: AppPropTypes.presence,
   facilitatorName: PropTypes.string,
   isTabletOrAbove: PropTypes.bool.isRequired,
+  retro: AppPropTypes.retro.isRequired,
 }
 
 RemoteRetro.defaultProps = {

--- a/web/static/js/components/remote_retro.jsx
+++ b/web/static/js/components/remote_retro.jsx
@@ -39,6 +39,7 @@ export class RemoteRetro extends Component {
       facilitatorName,
       isTabletOrAbove,
       retro,
+      actions,
     } = this.props
 
     return (
@@ -55,7 +56,7 @@ export class RemoteRetro extends Component {
         <Alert config={alert} />
         <Error config={error} />
         <DoorChime presences={presences} />
-        <StageHelp retro={retro} />
+        <StageHelp retro={retro} actions={actions} />
       </div>
     )
   }

--- a/web/static/js/components/remote_retro.jsx
+++ b/web/static/js/components/remote_retro.jsx
@@ -13,6 +13,7 @@ import Room from "./room"
 import Alert from "./alert"
 import Error from "./error"
 import DoorChime from "./door_chime"
+import StageHelp from "./stage_help"
 
 export class RemoteRetro extends Component {
   // Trigger analytics events on page load and stage changes
@@ -53,6 +54,7 @@ export class RemoteRetro extends Component {
         <Alert config={alert} />
         <Error config={error} />
         <DoorChime presences={presences} />
+        <StageHelp />
       </div>
     )
   }

--- a/web/static/js/components/stage_help.jsx
+++ b/web/static/js/components/stage_help.jsx
@@ -1,0 +1,62 @@
+import React from "react"
+import ReactDOM from "react-dom"
+
+import { connect } from "react-redux"
+import { bindActionCreators } from "redux"
+import { actions } from "../redux/retro"
+
+import * as AppPropTypes from "../prop_types"
+import STAGES from "../configs/stages"
+
+export const StageHelp = props => {
+  const handleClick = () => {
+    const { retro, actions: { showStageHelp } } = props
+    showStageHelp(retro)
+  }
+
+  const showIcon = () => {
+    const { retro: { stage } } = props
+    const validHelpStages = [
+      STAGES.PRIME_DIRECTIVE,
+      STAGES.IDEA_GENERATION,
+      STAGES.GROUPING,
+      STAGES.VOTING,
+      STAGES.ACTION_ITEMS,
+      STAGES.CLOSED,
+    ]
+    return validHelpStages.includes(stage)
+  }
+
+  if (showIcon()) {
+    return ReactDOM.createPortal(
+      <div className="portal">
+        <i
+          title="Access Stage Information"
+          className="question circle icon"
+          onClick={handleClick}
+          onKeyPress={handleClick}
+        />
+      </div>,
+      document.getElementById("stage-help-icon")
+    )
+  }
+
+  return null
+}
+
+const mapStateToProps = state => {
+  return {
+    retro: state.retro,
+  }
+}
+
+const mapDispatchToProps = dispatch => ({
+  actions: bindActionCreators(actions, dispatch),
+})
+
+StageHelp.propTypes = {
+  retro: AppPropTypes.retro.isRequired,
+  actions: AppPropTypes.actions.isRequired,
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(StageHelp)

--- a/web/static/js/components/stage_help.jsx
+++ b/web/static/js/components/stage_help.jsx
@@ -6,7 +6,7 @@ import { bindActionCreators } from "redux"
 import { actions } from "../redux/retro"
 
 import * as AppPropTypes from "../prop_types"
-import STAGES from "../configs/stages"
+import stageConfig from "../configs/stage_configs"
 
 export const StageHelp = props => {
   const handleClick = () => {
@@ -16,15 +16,7 @@ export const StageHelp = props => {
 
   const showIcon = () => {
     const { retro: { stage } } = props
-    const validHelpStages = [
-      STAGES.PRIME_DIRECTIVE,
-      STAGES.IDEA_GENERATION,
-      STAGES.GROUPING,
-      STAGES.VOTING,
-      STAGES.ACTION_ITEMS,
-      STAGES.CLOSED,
-    ]
-    return validHelpStages.includes(stage)
+    return (stageConfig[stage] && stageConfig[stage].help)
   }
 
   if (showIcon()) {
@@ -44,12 +36,6 @@ export const StageHelp = props => {
   return null
 }
 
-const mapStateToProps = state => {
-  return {
-    retro: state.retro,
-  }
-}
-
 const mapDispatchToProps = dispatch => ({
   actions: bindActionCreators(actions, dispatch),
 })
@@ -59,4 +45,4 @@ StageHelp.propTypes = {
   actions: AppPropTypes.actions.isRequired,
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(StageHelp)
+export default connect(null, mapDispatchToProps)(StageHelp)

--- a/web/static/js/components/stage_help.jsx
+++ b/web/static/js/components/stage_help.jsx
@@ -1,10 +1,6 @@
 import React from "react"
 import ReactDOM from "react-dom"
 
-import { connect } from "react-redux"
-import { bindActionCreators } from "redux"
-import { actions } from "../redux/retro"
-
 import * as AppPropTypes from "../prop_types"
 import stageConfig from "../configs/stage_configs"
 
@@ -16,7 +12,7 @@ export const StageHelp = props => {
 
   const showIcon = () => {
     const { retro: { stage } } = props
-    return (stageConfig[stage] && stageConfig[stage].help)
+    return stageConfig[stage].help
   }
 
   if (showIcon()) {
@@ -36,13 +32,9 @@ export const StageHelp = props => {
   return null
 }
 
-const mapDispatchToProps = dispatch => ({
-  actions: bindActionCreators(actions, dispatch),
-})
-
 StageHelp.propTypes = {
   retro: AppPropTypes.retro.isRequired,
   actions: AppPropTypes.actions.isRequired,
 }
 
-export default connect(null, mapDispatchToProps)(StageHelp)
+export default StageHelp

--- a/web/static/js/configs/stage_configs.jsx
+++ b/web/static/js/configs/stage_configs.jsx
@@ -21,6 +21,10 @@ const baseIdeaGenerationConfig = {
     headerText: "Stage Change: Idea Generation!",
     BodyComponent: StageChangeInfoIdeaGeneration,
   },
+  help: {
+    headerText: "Idea Generation",
+    BodyComponent: StageChangeInfoIdeaGeneration,
+  },
 }
 const ideaGenerationConfig = localStorage.groupingDev ? {
   ...baseIdeaGenerationConfig,
@@ -43,6 +47,7 @@ const ideaGenerationConfig = localStorage.groupingDev ? {
 export default {
   [LOBBY]: {
     alert: null,
+    help: null,
     confirmationMessage: "Has your entire party arrived?",
     nextStage: PRIME_DIRECTIVE,
     progressionButton: {
@@ -53,6 +58,10 @@ export default {
   [PRIME_DIRECTIVE]: {
     alert: {
       headerText: "Stage Change: The Prime Directive!",
+      BodyComponent: StageChangeInfoPrimeDirective,
+    },
+    help: {
+      headerText: "The Prime Directive",
       BodyComponent: StageChangeInfoPrimeDirective,
     },
     confirmationMessage: "Is everyone ready to begin?",
@@ -68,6 +77,10 @@ export default {
       headerText: "Stage Change: Grouping!",
       BodyComponent: StageChangeInfoGrouping,
     },
+    help: {
+      headerText: "Grouping",
+      BodyComponent: StageChangeInfoGrouping,
+    },
     confirmationMessage: "Are you sure you would like to proceed to the voting stage?",
     nextStage: VOTING,
     progressionButton: {
@@ -78,6 +91,10 @@ export default {
   [VOTING]: {
     alert: {
       headerText: "Stage Change: Voting!",
+      BodyComponent: StageChangeInfoVoting,
+    },
+    help: {
+      headerText: "Voting",
       BodyComponent: StageChangeInfoVoting,
     },
     confirmationMessage: "Are you sure you would like to proceed to the action items stage?",
@@ -92,6 +109,10 @@ export default {
       headerText: "Stage Change: Action-Item Generation!",
       BodyComponent: StageChangeInfoActionItems,
     },
+    help: {
+      headerText: "Action-Item Generation",
+      BodyComponent: StageChangeInfoActionItems,
+    },
     confirmationMessage: "Are you sure you want to distribute this retrospective's action items? This will close the retro.",
     nextStage: CLOSED,
     progressionButton: {
@@ -102,6 +123,10 @@ export default {
   [CLOSED]: {
     alert: {
       headerText: "Retro: Closed!",
+      BodyComponent: StageChangeInfoClosed,
+    },
+    help: {
+      headerText: "Retro is Closed!",
       BodyComponent: StageChangeInfoClosed,
     },
     confirmationMessage: null,

--- a/web/static/js/prop_types.js
+++ b/web/static/js/prop_types.js
@@ -58,3 +58,11 @@ export const votes = PropTypes.arrayOf(PropTypes.object)
 export const ideas = PropTypes.arrayOf(idea)
 
 export const actions = PropTypes.object
+
+export const retro = PropTypes.shape({
+  facilitator_id: PropTypes.number,
+  id: PropTypes.string,
+  inserted_at: PropTypes.string,
+  stage,
+  updated_at: PropTypes.string,
+})

--- a/web/static/js/redux/alert.js
+++ b/web/static/js/redux/alert.js
@@ -1,5 +1,7 @@
 const types = {
   CLEAR_ALERT: "CLEAR_ALERT",
+  RETRO_UPDATE_COMMITTED: "RETRO_UPDATE_COMMITTED",
+  SHOW_STAGE_HELP: "SHOW_STAGE_HELP",
 }
 
 export const actions = {
@@ -8,9 +10,13 @@ export const actions = {
 
 export const reducer = (state = null, action) => {
   switch (action.type) {
-    case "RETRO_UPDATE_COMMITTED": {
+    case types.RETRO_UPDATE_COMMITTED: {
       const { retro, stageConfigs } = action
       return stageConfigs[retro.stage].alert
+    }
+    case types.SHOW_STAGE_HELP: {
+      const { retro, stageConfigs } = action
+      return stageConfigs[retro.stage].help
     }
     case types.CLEAR_ALERT:
       return null

--- a/web/static/js/redux/alert.js
+++ b/web/static/js/redux/alert.js
@@ -1,6 +1,7 @@
-const types = {
+import { types as retroTypes } from "./retro"
+
+export const types = {
   CLEAR_ALERT: "CLEAR_ALERT",
-  RETRO_UPDATE_COMMITTED: "RETRO_UPDATE_COMMITTED",
   SHOW_STAGE_HELP: "SHOW_STAGE_HELP",
 }
 
@@ -10,13 +11,13 @@ export const actions = {
 
 export const reducer = (state = null, action) => {
   switch (action.type) {
-    case types.RETRO_UPDATE_COMMITTED: {
+    case retroTypes.RETRO_UPDATE_COMMITTED: {
       const { retro, stageConfigs } = action
-      return stageConfigs[retro.stage].alert
+      return stageConfigs[retro.stage].alert || null
     }
     case types.SHOW_STAGE_HELP: {
       const { retro, stageConfigs } = action
-      return stageConfigs[retro.stage].help
+      return stageConfigs[retro.stage].help || null
     }
     case types.CLEAR_ALERT:
       return null

--- a/web/static/js/redux/retro.js
+++ b/web/static/js/redux/retro.js
@@ -5,6 +5,7 @@ export const types = {
   RETRO_UPDATE_COMMITTED: "RETRO_UPDATE_COMMITTED",
   RETRO_UPDATE_REQUESTED: "RETRO_UPDATE_REQUESTED",
   RETRO_UPDATE_REJECTED: "RETRO_UPDATE_REJECTED",
+  SHOW_STAGE_HELP: "SHOW_STAGE_HELP",
 }
 
 export const actions = {
@@ -30,6 +31,12 @@ export const actions = {
   setInitialState: initialState => ({
     type: types.SET_INITIAL_STATE,
     initialState,
+  }),
+
+  showStageHelp: retro => ({
+    type: types.SHOW_STAGE_HELP,
+    retro,
+    stageConfigs,
   }),
 }
 

--- a/web/static/js/redux/retro.js
+++ b/web/static/js/redux/retro.js
@@ -1,11 +1,11 @@
 import stageConfigs from "../configs/stage_configs"
+import { types as alertTypes } from "./alert"
 
 export const types = {
   SET_INITIAL_STATE: "SET_INITIAL_STATE",
   RETRO_UPDATE_COMMITTED: "RETRO_UPDATE_COMMITTED",
   RETRO_UPDATE_REQUESTED: "RETRO_UPDATE_REQUESTED",
   RETRO_UPDATE_REJECTED: "RETRO_UPDATE_REJECTED",
-  SHOW_STAGE_HELP: "SHOW_STAGE_HELP",
 }
 
 export const actions = {
@@ -34,7 +34,7 @@ export const actions = {
   }),
 
   showStageHelp: retro => ({
-    type: types.SHOW_STAGE_HELP,
+    type: alertTypes.SHOW_STAGE_HELP,
     retro,
     stageConfigs,
   }),


### PR DESCRIPTION
__Description of Change(s) Introduced:__ 

- Adds a question mark icon to the header which, when clicked,
invokes the stage breakdown modal for the current retro stage.

- Adds a new redux action for alerts to invoke help.

- Adds a new 'help' key to the stageConfig.js to show abbreviated
header for the help modal (does not show "Stage Change! when it
is help).

- Since the header exists outside of the react dom, uses a React
portal to render the question icon.

- Quesion mark icon renders conditionally based on stage, only
showing when there is help to be shown.

__Description of Testing Applied:__

Enzyme tests for new `StageHelp` component.

__Relevant github Issue:__ (if applicable)

- Issue #489
