### PR TITLE
Change "you're" to "we're" to sound more inclusive and welcoming.

### DIFF
--- a/web/static/js/configs/happy_sad_confused_stage_configs.js
+++ b/web/static/js/configs/happy_sad_confused_stage_configs.js
@@ -20,7 +20,7 @@ const {
 const StageChangeInfoIdeaGeneration = stageChangeInfoIdeaGenerationBuilder([
   "Reflect on the events of this past sprint.",
   "Submit items that made you happy, sad, or just plain confused.",
-  "Assume best intent; you're all here to improve.",
+  "Assume best intent; we're all here to improve.",
 ])
 
 const baseIdeaGenerationConfig = {

--- a/web/static/js/configs/start_stop_continue_stage_configs.js
+++ b/web/static/js/configs/start_stop_continue_stage_configs.js
@@ -19,7 +19,7 @@ const {
 const StageChangeInfoIdeaGeneration = stageChangeInfoIdeaGenerationBuilder([
   "Reflect on the practices and habits of the team.",
   "Suggest practices that the team could start, stop, or continue to make the team more effective.",
-  "Be thoughful with your language. You're here to improve the team.",
+  "Be thoughful with your language. We're here to improve the team.",
 ])
 
 export default {


### PR DESCRIPTION
__Description of Change(s) Introduced:__ 
Change "you're" to "we're" to sound more inclusive and welcoming.
