### PR TITLE
notifies facilitator if all votes are cast - Addresses issue #435

### DIFF
--- a/test/components/stage_progression_button_test.js
+++ b/test/components/stage_progression_button_test.js
@@ -153,6 +153,53 @@ describe("StageProgressionButton", () => {
         expect(stageProgressionButton.find("div")).to.have.length(0)
       })
     })
+
+    context("when stateDependentTooltip returns a value", () => {
+      beforeEach(() => {
+        const props = {
+          ...defaultProps,
+          config: { ...config, stateDependentTooltip: () => "All in!" },
+        }
+        stageProgressionButton = mountWithConnectedSubcomponents(
+          <StageProgressionButton {...props} />
+        )
+      })
+
+      it("renders tooltip", () => {
+        expect(stageProgressionButton.find(".tooltip").text()).to.equal("All in!")
+      })
+    })
+
+    context("when stateDependentTooltip does not return a value", () => {
+      beforeEach(() => {
+        const props = {
+          ...defaultProps,
+          config: { ...config, stateDependentTooltip: () => null },
+        }
+        stageProgressionButton = mountWithConnectedSubcomponents(
+          <StageProgressionButton {...props} />
+        )
+      })
+
+      it("does not render tooltip", () => {
+        expect(stageProgressionButton.find(".tooltip")).to.have.length(0)
+      })
+    })
+
+    context("when stateDependentTooltip does not exisit", () => {
+      beforeEach(() => {
+        const props = {
+          ...defaultProps,
+        }
+        stageProgressionButton = mountWithConnectedSubcomponents(
+          <StageProgressionButton {...props} />
+        )
+      })
+
+      it("does not render tooltip", () => {
+        expect(stageProgressionButton.find(".tooltip")).to.have.length(0)
+      })
+    })
   })
 
   describe("when it does not receive a progressionButton configuration object", () => {

--- a/web/static/js/components/centered_content_lower_third_wrapper.jsx
+++ b/web/static/js/components/centered_content_lower_third_wrapper.jsx
@@ -4,7 +4,7 @@ import StageProgressionButton from "./stage_progression_button"
 import * as AppPropTypes from "../prop_types"
 
 const CenteredLowerThirdContentWrapper = props => {
-  const { currentUser, children, stageConfig } = props
+  const { currentUser, children, stageConfig, presences } = props
 
   return (
     <div className="ui stackable grid basic attached secondary center aligned segment">
@@ -15,6 +15,7 @@ const CenteredLowerThirdContentWrapper = props => {
       {currentUser.is_facilitator && (
         <StageProgressionButton
           currentUser={currentUser}
+          presences={presences}
           config={stageConfig.progressionButton}
           className="three wide column"
         />
@@ -25,6 +26,7 @@ const CenteredLowerThirdContentWrapper = props => {
 
 CenteredLowerThirdContentWrapper.propTypes = {
   currentUser: AppPropTypes.presence.isRequired,
+  presences: AppPropTypes.presences.isRequired,
   stageConfig: AppPropTypes.stageConfig.isRequired,
   children: PropTypes.node.isRequired,
 }

--- a/web/static/js/components/centered_content_lower_third_wrapper.jsx
+++ b/web/static/js/components/centered_content_lower_third_wrapper.jsx
@@ -4,7 +4,7 @@ import StageProgressionButton from "./stage_progression_button"
 import * as AppPropTypes from "../prop_types"
 
 const CenteredLowerThirdContentWrapper = props => {
-  const { currentUser, children, stageConfig, presences } = props
+  const { currentUser, children, stageConfig } = props
 
   return (
     <div className="ui stackable grid basic attached secondary center aligned segment">
@@ -15,7 +15,6 @@ const CenteredLowerThirdContentWrapper = props => {
       {currentUser.is_facilitator && (
         <StageProgressionButton
           currentUser={currentUser}
-          presences={presences}
           config={stageConfig.progressionButton}
           className="three wide column"
         />
@@ -26,7 +25,6 @@ const CenteredLowerThirdContentWrapper = props => {
 
 CenteredLowerThirdContentWrapper.propTypes = {
   currentUser: AppPropTypes.presence.isRequired,
-  presences: AppPropTypes.presences.isRequired,
   stageConfig: AppPropTypes.stageConfig.isRequired,
   children: PropTypes.node.isRequired,
 }

--- a/web/static/js/components/css_modules/stage_progression_button.css
+++ b/web/static/js/components/css_modules/stage_progression_button.css
@@ -14,3 +14,9 @@
     }
   }
 }
+
+:global(.ui.stackable.grid>.column:not(.row)).index .pointing-label {
+  z-index: 0;
+  top: -2em;
+  left: 33%;
+}

--- a/web/static/js/components/css_modules/stage_progression_button.css
+++ b/web/static/js/components/css_modules/stage_progression_button.css
@@ -17,6 +17,6 @@
 
 :global(.ui.stackable.grid>.column:not(.row)).index .pointing-label {
   z-index: 0;
-  top: -2em;
+  top: -3em;
   left: 33%;
 }

--- a/web/static/js/components/stage_progression_button.jsx
+++ b/web/static/js/components/stage_progression_button.jsx
@@ -1,15 +1,12 @@
 import React, { Component } from "react"
 import { connect } from "react-redux"
 import { bindActionCreators } from "redux"
-import isEmpty from "lodash/isEmpty"
 
 import PropTypes from "prop-types"
 import Modal from "react-modal"
 import * as AppPropTypes from "../prop_types"
 import styles from "./css_modules/stage_progression_button.css"
 import { actions as actionCreators } from "../redux"
-import { VOTE_LIMIT } from "../configs/retro_configs"
-
 
 export class StageProgressionButton extends Component {
   state = { modalOpen: false }
@@ -36,17 +33,17 @@ export class StageProgressionButton extends Component {
       buttonDisabled,
       className,
       currentUser,
-      presences,
+      reduxState,
       retroUpdateRequested,
       config,
-      votes,
     } = this.props
 
     const { modalOpen } = this.state
-    const showAllVotesInPrompt = !isEmpty(presences)
-      && (votes.length >= VOTE_LIMIT * presences.length)
 
     if (!config || !currentUser.is_facilitator) return null
+
+    const { stateDependentTooltip } = config
+    const tooltipText = stateDependentTooltip ? stateDependentTooltip(reduxState) : null
 
     return (
       <div className={`${className} ${styles.index}`}>
@@ -78,9 +75,9 @@ export class StageProgressionButton extends Component {
             </button>
           </div>
         </Modal>
-        { showAllVotesInPrompt && (
-          <div className={`${styles.pointingLabel} floating ui pointing below teal label`}>
-            All votes in!
+        { tooltipText && (
+          <div className={`${styles.pointingLabel} floating ui pointing below teal label tooltip`}>
+            {tooltipText}
           </div>
         )}
         <button
@@ -104,15 +101,12 @@ StageProgressionButton.propTypes = {
   config: PropTypes.object,
   reduxState: PropTypes.object,
   buttonDisabled: PropTypes.bool,
-  presences: AppPropTypes.presences,
   retroUpdateRequested: PropTypes.bool,
-  votes: AppPropTypes.votes.isRequired,
 }
 
 StageProgressionButton.defaultProps = {
   className: "",
   buttonDisabled: false,
-  presences: [],
   retroUpdateRequested: false,
   reduxState: {},
   config: null,
@@ -121,7 +115,6 @@ StageProgressionButton.defaultProps = {
 const mapStateToProps = reduxState => ({
   reduxState,
   retroUpdateRequested: reduxState.retro.updateRequested,
-  votes: reduxState.votes,
 })
 
 const mapDispatchToProps = dispatch => ({

--- a/web/static/js/components/stage_progression_button.jsx
+++ b/web/static/js/components/stage_progression_button.jsx
@@ -9,7 +9,7 @@ import styles from "./css_modules/stage_progression_button.css"
 import { actions as actionCreators } from "../redux"
 
 export class StageProgressionButton extends Component {
-  state = { modalOpen: false }
+  state = { modalOpen: false, showSubmitIdeaPrompt: true }
 
   handleStageProgressionButtonClick = () => {
     this.setState({ modalOpen: true })
@@ -37,7 +37,7 @@ export class StageProgressionButton extends Component {
       config,
     } = this.props
 
-    const { modalOpen } = this.state
+    const { modalOpen, showSubmitIdeaPrompt } = this.state
 
     if (!config || !currentUser.is_facilitator) return null
 
@@ -71,6 +71,11 @@ export class StageProgressionButton extends Component {
             </button>
           </div>
         </Modal>
+        { showSubmitIdeaPrompt && (
+          <div className={`${styles.pointingLabel} floating ui pointing below teal label`}>
+            All votes in!
+          </div>
+        )}
         <button
           className="fluid ui right labeled blue icon button"
           onClick={this.handleStageProgressionButtonClick}

--- a/web/static/js/components/stage_progression_button.jsx
+++ b/web/static/js/components/stage_progression_button.jsx
@@ -1,15 +1,18 @@
 import React, { Component } from "react"
 import { connect } from "react-redux"
 import { bindActionCreators } from "redux"
+import isEmpty from "lodash/isEmpty"
 
 import PropTypes from "prop-types"
 import Modal from "react-modal"
 import * as AppPropTypes from "../prop_types"
 import styles from "./css_modules/stage_progression_button.css"
 import { actions as actionCreators } from "../redux"
+import { VOTE_LIMIT } from "../configs/retro_configs"
+
 
 export class StageProgressionButton extends Component {
-  state = { modalOpen: false, showSubmitIdeaPrompt: true }
+  state = { modalOpen: false }
 
   handleStageProgressionButtonClick = () => {
     this.setState({ modalOpen: true })
@@ -33,11 +36,15 @@ export class StageProgressionButton extends Component {
       buttonDisabled,
       className,
       currentUser,
+      presences,
       retroUpdateRequested,
       config,
+      votes,
     } = this.props
 
-    const { modalOpen, showSubmitIdeaPrompt } = this.state
+    const { modalOpen } = this.state
+    const showAllVotesInPrompt = !isEmpty(presences)
+      && (votes.length >= VOTE_LIMIT * presences.length)
 
     if (!config || !currentUser.is_facilitator) return null
 
@@ -71,7 +78,7 @@ export class StageProgressionButton extends Component {
             </button>
           </div>
         </Modal>
-        { showSubmitIdeaPrompt && (
+        { showAllVotesInPrompt && (
           <div className={`${styles.pointingLabel} floating ui pointing below teal label`}>
             All votes in!
           </div>
@@ -97,12 +104,15 @@ StageProgressionButton.propTypes = {
   config: PropTypes.object,
   reduxState: PropTypes.object,
   buttonDisabled: PropTypes.bool,
+  presences: AppPropTypes.presences,
   retroUpdateRequested: PropTypes.bool,
+  votes: AppPropTypes.votes.isRequired,
 }
 
 StageProgressionButton.defaultProps = {
   className: "",
   buttonDisabled: false,
+  presences: [],
   retroUpdateRequested: false,
   reduxState: {},
   config: null,
@@ -111,6 +121,7 @@ StageProgressionButton.defaultProps = {
 const mapStateToProps = reduxState => ({
   reduxState,
   retroUpdateRequested: reduxState.retro.updateRequested,
+  votes: reduxState.votes,
 })
 
 const mapDispatchToProps = dispatch => ({

--- a/web/static/js/configs/happy_sad_confused_stage_configs.js
+++ b/web/static/js/configs/happy_sad_confused_stage_configs.js
@@ -6,6 +6,7 @@ import StageChangeInfoClosed from "../components/stage_change_info_closed"
 import StageChangeInfoActionItems from "../components/stage_change_info_action_items"
 import StageChangeInfoPrimeDirective from "../components/stage_change_info_prime_directive"
 import STAGES from "./stages"
+import { VOTE_LIMIT } from "./retro_configs"
 
 const {
   LOBBY,
@@ -112,6 +113,13 @@ export default {
       copy: "Proceed to Action Items",
       iconClass: "arrow right",
       confirmationMessage: "Are you sure you would like to proceed to the action items stage?",
+      stateDependentTooltip: reduxState => {
+        const { votes, presences } = reduxState
+        if (votes.length >= VOTE_LIMIT * presences.length) {
+          return "All Votes in!"
+        }
+        return null
+      },
     },
   },
   [ACTION_ITEMS]: {

--- a/web/static/js/configs/start_stop_continue_stage_configs.js
+++ b/web/static/js/configs/start_stop_continue_stage_configs.js
@@ -5,6 +5,7 @@ import StageChangeInfoClosed from "../components/stage_change_info_closed"
 import StageChangeInfoActionItems from "../components/stage_change_info_action_items"
 import StageChangeInfoPrimeDirective from "../components/stage_change_info_prime_directive"
 import STAGES from "./stages"
+import { VOTE_LIMIT } from "./retro_configs"
 
 const {
   LOBBY,
@@ -95,6 +96,13 @@ export default {
       copy: "Proceed to Action Items",
       iconClass: "arrow right",
       confirmationMessage: "Are you sure you would like to proceed to the action items stage?",
+      stateDependentTooltip: reduxState => {
+        const { votes, presences } = reduxState
+        if (votes.length >= VOTE_LIMIT * presences.length) {
+          return "All Votes in!"
+        }
+        return null
+      },
     },
   },
   [ACTION_ITEMS]: {


### PR DESCRIPTION
Hey! 

I'm not sure if this issue has already been claimed but thought I'd give it a shot! I'm looking to contribute to more open source projects and this looked liked a great place to start. I had a bunch of fun navigating the code and implementing this feature. I'm very open to your feedback and suggestions on the approach here. I have a couple of line-level questions that I've added in comments.
Peter

__Description of Change(s) Introduced:__ 
 - [x] in the voting stage, when every user currently present in a retro has submitted all of their votes, a teal, Semantic UI 'pointing label' appears above the stage progression button, reading "All votes in!"

__Dependencies Introduced or Upgraded:__ (if applicable)

- N/A

__Description of Testing Applied:__ (if applicable)

- No tests added yet

__Relevant Screenshots/GIFs:__ (if applicable)

<img width="162" alt="Screen Shot 2019-11-14 at 6 45 48 PM" src="https://user-images.githubusercontent.com/9774128/68905409-136c7400-070f-11ea-8c63-45f29268b9be.png">

__Relevant github Issue:__ (if applicable)
- [#435](https://github.com/stride-nyc/remote_retro/issues/435)
