### PR TITLE
sets default view to "start" in mobile view

### DIFF
--- a/test/redux/mobile_test.js
+++ b/test/redux/mobile_test.js
@@ -12,9 +12,7 @@ describe("mobile", () => {
         it("returns an object with default selected category of 'happy'", () => {
           const unhandledAction = { type: "IHAVENOIDEAWHATSHAPPENING" }
 
-          expect(reducer(undefined, unhandledAction)).to.eql({
-            selectedCategoryTab: "happy",
-          })
+          expect(reducer(undefined, unhandledAction)).to.eql({})
         })
       })
 
@@ -53,6 +51,26 @@ describe("mobile", () => {
         expect(
           actions.categoryTabSelected("sad")
         ).to.deep.equal({ type: "CATEGORY_TAB_SELECTED", category: "sad" })
+      })
+    })
+  })
+
+  describe("when the application bootstraps", () => {
+    describe("when the retro is a Happy/Sad/Confused retro", () => {
+      it("provides a list of lower-cased categories", () => {
+        const initialState = deepFreeze([])
+        const unhandledAction = { type: "SET_INITIAL_STATE", initialState: { format: "Happy/Sad/Confused" } }
+
+        expect(reducer(initialState, unhandledAction)).to.eql({ selectedCategoryTab: "happy" })
+      })
+    })
+
+    describe("when the retro is a Start/Stop/Continue retro", () => {
+      it("provides a list of lower-cased categories", () => {
+        const initialState = deepFreeze([])
+        const unhandledAction = { type: "SET_INITIAL_STATE", initialState: { format: "Start/Stop/Continue" } }
+
+        expect(reducer(initialState, unhandledAction)).to.eql({ selectedCategoryTab: "start" })
       })
     })
   })

--- a/web/static/js/redux/mobile.js
+++ b/web/static/js/redux/mobile.js
@@ -1,3 +1,5 @@
+import { types as retroTypes } from "./retro"
+
 const types = {
   CATEGORY_TAB_SELECTED: "CATEGORY_TAB_SELECTED",
 }
@@ -6,12 +8,17 @@ export const actions = {
   categoryTabSelected: category => ({ type: types.CATEGORY_TAB_SELECTED, category }),
 }
 
-const defaultInitialState = {
-  selectedCategoryTab: "happy",
+const formatToSelectedCategory = {
+  "Happy/Sad/Confused": "happy",
+  "Start/Stop/Continue": "start",
 }
 
-export const reducer = (state = defaultInitialState, action) => {
+export const reducer = (state = {}, action) => {
   switch (action.type) {
+    case retroTypes.SET_INITIAL_STATE: {
+      const { initialState } = action
+      return { selectedCategoryTab: formatToSelectedCategory[initialState.format] }
+    }
     case types.CATEGORY_TAB_SELECTED:
       return { ...state, selectedCategoryTab: action.category }
     default:


### PR DESCRIPTION
__Description of Change(s) Introduced:__ 
- I noticed while in the "Start/Stop/Continue" format in the mobile view the default behavior does not show the list items (see below image). To address this I changed the default state to an empty object and update the state to the appropriate value (`"start"` / `"stop"`) when the `SET_INITIAL_STATE` action is fired.

__Dependencies Introduced or Upgraded:__ (if applicable)

- N/A

__Description of Testing Applied:__ (if applicable)

- Updated default initial state
- Updated the tests to determine which selectedCategoryTab to apply when the application bootstraps

__Relevant Screenshots/GIFs:__ (if applicable)

<img width="379" alt="Screen Shot 2019-11-15 at 6 06 42 PM" src="https://user-images.githubusercontent.com/9774128/68981882-fc8f5580-07d2-11ea-96bb-294a5beee4b5.png">
<img width="379" alt="Screen Shot 2019-11-15 at 6 07 08 PM" src="https://user-images.githubusercontent.com/9774128/68981876-f9946500-07d2-11ea-9d9e-0f4bff5f24d0.png">

__Relevant github Issue:__ (if applicable)

- No issue filed - let me know if you would like for me to file an issue for your records
