### PR TITLE
Make Grouping Cards Scrollable

### DIFF
--- a/web/static/js/components/css_modules/grouping_idea_card.css
+++ b/web/static/js/components/css_modules/grouping_idea_card.css
@@ -11,6 +11,7 @@
   z-index: var(--grouping-card-z-index);
 
   max-width: 250px;
+  word-wrap: break-word;
 
   transition: border 0.15s, box-shadow 0.15s;
 
@@ -22,8 +23,7 @@
   font-size: 12px;
   padding: var(--vertical-padding) 8px;
 
-  /* only show two lines of text to preserve real estate on grouping board */
-  overflow: hidden;
+  overflow: auto;
   max-height: calc(
     (var(--semantic-line-height) * var(--max-lines-to-show)) +
     (var(--vertical-padding) * 2) +


### PR DESCRIPTION
__Description of Change(s) Introduced:__ 

From #571 , the retro item message is truncated after 2 lines. We changed the card to be scrollable so the entire message can be seen without compromising on board real-estate.

__Dependencies Introduced or Upgraded:__ (if applicable)

- N/A

__Description of Testing Applied:__ (if applicable)

- Manually dragged cards around board and ensured grouping works on board
- Moved to Labeling stage successfully

__Relevant Screenshots/GIFs:__ (if applicable)

![Screen Shot 2020-05-29 at 6 54 08 PM](https://user-images.githubusercontent.com/10553889/83311698-f8aaaa00-a1dd-11ea-82f1-3ac6763be0ce.png)

__Relevant github Issue:__ 

- [issue (571)](#571 )

