### PR TITLE
Add: Tabindex to labels for facilitators

### DIFF
--- a/web/static/js/components/group_label_container.jsx
+++ b/web/static/js/components/group_label_container.jsx
@@ -9,7 +9,7 @@ import stages from "../configs/stages"
 
 const { LABELING_PLUS_VOTING } = stages
 
-const GroupLabelContainer = ({ groupWithAssociatedIdeasAndVotes, currentUser, actions, stage }) => {
+const GroupLabelContainer = ({ groupWithAssociatedIdeasAndVotes, currentUser, actions, stage, index }) => {
   const displayGroupLabelInput = (currentUser.is_facilitator && stage === LABELING_PLUS_VOTING)
   const readonlyGroupLabelClasses = classNames("readonly-group-label", sharedGroupLabelTextStyles.groupLabelText, {
     unlabeled: !groupWithAssociatedIdeasAndVotes.label,
@@ -21,6 +21,7 @@ const GroupLabelContainer = ({ groupWithAssociatedIdeasAndVotes, currentUser, ac
         <GroupLabelInput
           actions={actions}
           groupWithAssociatedIdeasAndVotes={groupWithAssociatedIdeasAndVotes}
+          index={index}
         />
       ) : (
         <p

--- a/web/static/js/components/group_label_input.jsx
+++ b/web/static/js/components/group_label_input.jsx
@@ -57,6 +57,7 @@ class GroupLabelInput extends Component {
 
   render() {
     const { groupLabelInputValue } = this.state
+    const { index } = this.props
 
     return (
       <div className="ui fluid input">
@@ -66,6 +67,7 @@ class GroupLabelInput extends Component {
           placeholder="Optional Group Label"
           value={groupLabelInputValue}
           maxLength={MAX_LENGTH_OF_GROUP_NAME}
+          tabIndex={index}
           onChange={this.handleChange}
         />
 

--- a/web/static/js/components/groups_container.jsx
+++ b/web/static/js/components/groups_container.jsx
@@ -73,11 +73,12 @@ export class GroupsContainer extends Component {
               leaveAnimation="none"
               typeName={null}
             >
-              {groupsSorted.map(groupWithAssociatedIdeasAndVotes => (
+              {groupsSorted.map((groupWithAssociatedIdeasAndVotes, index) => (
                 <IdeaGroup
                   actions={actions}
                   currentUser={currentUser}
                   currentUserHasExhaustedVotes={currentUserHasExhaustedVotes}
+                  index={index}
                   key={groupWithAssociatedIdeasAndVotes.id}
                   stage={stage}
                   groupWithAssociatedIdeasAndVotes={groupWithAssociatedIdeasAndVotes}

--- a/web/static/js/components/idea_group.jsx
+++ b/web/static/js/components/idea_group.jsx
@@ -32,6 +32,7 @@ class IdeaGroup extends Component {
       currentUser,
       actions,
       stage,
+      index,
       currentUserHasExhaustedVotes,
     } = this.props
 
@@ -45,6 +46,7 @@ class IdeaGroup extends Component {
           actions={actions}
           currentUser={currentUser}
           groupWithAssociatedIdeasAndVotes={groupWithAssociatedIdeasAndVotes}
+          index={index}
           stage={stage}
         />
 


### PR DESCRIPTION
__Description of Change(s) Introduced:__ 
Added tabindex to the changeable labels (only for facilitators) so they can tab to the next label
Now it tabs first to the vote button, what can be very annoying / confusing. 
Small quality of life improvement

__Description of Testing Applied:__ (if applicable)
Make a Retro, make multiple labels and tab trough them, You will go to the next label instead of first selecting the vote button(s)

__Relevant github Issue:__ (if applicable)
- [#385](https://github.com/stride-nyc/remote_retro/issues/583) Feature Request: Labeling face tab to next block
