### PR TITLE
fix unusable scroll bar on user list

### DIFF
--- a/web/static/js/components/css_modules/user_list.css
+++ b/web/static/js/components/css_modules/user_list.css
@@ -20,7 +20,8 @@
 :global(.basic.segment).index {
   :global(.wrap) {
     max-width: 75rem;
-    max-height: 24rem;
+    max-height: 12rem;
+    min-height: 8rem;
     display: inline-block;
     white-space: initial;
     overflow-x: auto;


### PR DESCRIPTION
__Description of Change(s) Introduced:__ 
Fixes the overflow issue on the users list. Related to bug report https://github.com/stride-nyc/remote_retro/issues/617

__Relevant Screenshots/GIFs:__ 
<img width="937" alt="Screenshot 2023-10-28 at 22 10 28" src="https://github.com/stride-nyc/remote_retro/assets/7046787/f8a75469-e4d8-47ed-98cb-9ce1758c58da">
<img width="1323" alt="Screenshot 2023-10-28 at 22 11 01" src="https://github.com/stride-nyc/remote_retro/assets/7046787/ed58f123-ac73-4543-85a8-462f018e5b06">


__Relevant github Issue:__
- [issue (617)](https://github.com/stride-nyc/remote_retro/issues/617)
