### PR TITLE
Make locale an optional user field to fix auth error

### DIFF
--- a/lib/remote_retro_web/models/user.ex
+++ b/lib/remote_retro_web/models/user.ex
@@ -6,7 +6,6 @@ defmodule RemoteRetro.User do
     :email,
     :google_user_info,
     :given_name,
-    :locale,
     :name,
     :picture,
     :last_login,
@@ -23,7 +22,7 @@ defmodule RemoteRetro.User do
     field(:google_user_info, :map)
     field(:family_name, :string)
     field(:given_name, :string)
-    field(:locale, :string)
+    field(:locale, :string, default: "en")
     field(:name, :string)
     field(:picture, :string)
     field(:last_login, :naive_datetime_usec)


### PR DESCRIPTION
__Description of Change(s) Introduced:__ 
- Fixes issue with new users authenticating with Google OAuth getting a 500. Google stopped sending locale, which was a required field. Now we supply a default as a hotfix.

__Description of Testing Applied:__
- Local testing replicates the 500 similar to #595 and the default value resolves it.

__Relevant github Issue:__ (if applicable)

- #595 
