### PR TITLE
Use non-deprecated buildpack

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,4 +1,4 @@
 https://github.com/gigalixir/gigalixir-buildpack-clean-cache.git
 https://github.com/HashNuke/heroku-buildpack-elixir
-https://github.com/gjaldon/heroku-buildpack-phoenix-static
+https://github.com/gigalixir/gigalixir-buildpack-phoenix-static
 https://github.com/gigalixir/gigalixir-buildpack-distillery.git


### PR DESCRIPTION
__Description of Change(s) Introduced:__ 
- The old heroku-buildpack-phoenix-static buildpack is EOL and replaced with gigalixir-buildpack-phoenix-static. See https://www.gigalixir.com/blog/end-of-life-phoenix-buildpack/
- Needed to address [broken deployment](https://app.circleci.com/pipelines/github/stride-nyc/remote_retro/343/workflows/e0aa7f33-9629-4ccd-9eb7-3c101ecbb201/jobs/3779)