### PR TITLE
Fix npm run compile-production

### DIFF
--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -15,7 +15,7 @@ module.exports = webpackMerge.smart(sharedConfig, {
   devtool: "source-map",
   optimization: {
     minimizer: [
-      new TerserPlugin({ sourceMap: true, parallel: true }),
+      new TerserPlugin({ terserOptions: { sourceMap: true, parallel: true }}),
       new OptimizeCSSAssetsPlugin({}),
     ],
   },

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -1,5 +1,5 @@
 const webpack = require("webpack")
-const webpackMerge = require("webpack-merge")
+const { merge } = require("webpack-merge")
 const OptimizeCSSAssetsPlugin = require("optimize-css-assets-webpack-plugin")
 const TerserPlugin = require("terser-webpack-plugin")
 const HoneybadgerSourceMapPlugin = require("@honeybadger-io/webpack")
@@ -10,12 +10,12 @@ const { HOST, HONEYBADGER_API_KEY, npm_package_gitHead, revision } = process.env
 
 const PRODUCTION_ASSETS_URL = `https://${HOST}`
 
-module.exports = webpackMerge.smart(sharedConfig, {
+module.exports = merge(sharedConfig, {
   mode: "production",
   devtool: "source-map",
   optimization: {
     minimizer: [
-      new TerserPlugin({ terserOptions: { sourceMap: true, parallel: true }}),
+      new TerserPlugin({ terserOptions: { sourceMap: true }, parallel: true }),
       new OptimizeCSSAssetsPlugin({}),
     ],
   },


### PR DESCRIPTION
__Description of Change(s) Introduced:__ 
- Pass [terserOptions](https://webpack.js.org/plugins/terser-webpack-plugin/#terseroptions) to TerserPlugin properly for v5 of plugin.
- Import [webpack-merge](https://github.com/survivejs/webpack-merge?tab=readme-ov-file#mergeconfiguration--configuration) properly for new version and cease use of smart merge, which has been removed.