### PR TITLE
Bust cache and update pins in phoenix buildpack

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 erlang 22.3.4.16
 elixir 1.11.4
-nodejs 20.2.0
+nodejs 20.14.0

--- a/phoenix_static_buildpack.config
+++ b/phoenix_static_buildpack.config
@@ -1,3 +1,4 @@
+clean_cache=true
 node_version=20.14.0
-npm_version=7.24.2
-yarn_version=1.22.0
+npm_version=10.7.0
+yarn_version=1.22.22


### PR DESCRIPTION
__Description of Change(s) Introduced:__ 
- Busts cache in Phoenix buildpack ([docs](https://github.com/gigalixir/gigalixir-buildpack-phoenix-static?tab=readme-ov-file#configuration))
- Pins the npm and yarn versions to those that work locally for production build
- Synchronizes local dev node version with buildpack version
