### PR TITLE
Use the recommended asset buildpack from gigalixir 🤦🏻‍♂️

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,4 +1,4 @@
 https://github.com/gigalixir/gigalixir-buildpack-clean-cache.git
 https://github.com/HashNuke/heroku-buildpack-elixir
-https://github.com/vanderhoop/heroku-buildpack-nodejs
+https://github.com/gigalixir/gigalixir-buildpack-phoenix-static
 https://github.com/gigalixir/gigalixir-buildpack-distillery.git


### PR DESCRIPTION
  - given the source code dependency upgrade reversions that went in in the last PR, the specific buildpack update that was made in https://github.com/stride-nyc/remote_retro/pull/624 no longer _needed_ to be reverted