### PR TITLE
Note that Datadog replaces Papertrail for logging

### DIFF
--- a/lib/remote_retro_web/templates/page/privacy.html.heex
+++ b/lib/remote_retro_web/templates/page/privacy.html.heex
@@ -27,8 +27,7 @@
     <li>Gigalixir on AWS (for application hosting)</li>
     <li>SendGrid (to send emails)</li>
     <li>Honeybadger (for exception reporting)</li>
-    <li>DataDog (for performance metrics)</li>
-    <li>Papertrail (for request logging)</li>
+    <li>DataDog (for performance metrics, RUM, and request logging)</li>
     <li>Hubspot (to manage email lists)</li>
     <li>Google (for authentication and site analytics)</li>
   </ul>
@@ -48,5 +47,5 @@
   <p>If you are in the EU and wish to exercise or discuss your GDPR rights, please contact us at <a href="mailto:remote_retro@stridenyc.com?subject=GDPR%20Inquiry">remote_retro@stridenyc.com</a>.</p>
 
   <h2 class="ui medium header">Last Updated</h2>
-  <p>May 2022</p>
+  <p>April 2026</p>
 </div>


### PR DESCRIPTION
__Description of Change(s) Introduced:__ 

- Updates privacy policy to indicate that Datadog now handles request logging
